### PR TITLE
feat: add user group to users_sync metadata

### DIFF
--- a/apps/backend/src/auth-strategy.ts
+++ b/apps/backend/src/auth-strategy.ts
@@ -96,6 +96,17 @@ export async function validateAuth(request: FastifyRequest): Promise<
       githubUsername,
     );
 
+    const NEON_EMPLOYEE_GROUP = 'neon';
+    const userGroup = user.serverMetadata?.user_group;
+    if (neonEmployee && userGroup !== NEON_EMPLOYEE_GROUP) {
+      await user.update({
+        serverMetadata: {
+          ...user.serverMetadata,
+          user_group: NEON_EMPLOYEE_GROUP,
+        },
+      });
+    }
+
     return {
       ...user,
       githubUsername,


### PR DESCRIPTION
## Descriptions

To allow us to easily query which apps were creted by non-neon employees, we need to inject that metadata into `users_sync`.

We can get users that weren't marked as Neon employees with this query:

```sql
SELECT * 
FROM neon_auth.users_sync 
WHERE raw_json -> 'server_metadata' ->> 'user_group' IS DISTINCT FROM 'neon';
```

![image](https://github.com/user-attachments/assets/ee3ad405-4cf0-4a5f-9685-815e797879e3)

**NOTES**

I haven't manually updated existing users, meaning that, until these users log in again, they won't be marked as Neon employees. 

Also, **DON'T UPDATE THESE THROUGH NEON** , neon_auth isn't prepared for 2 way sync, meaning, the data will get unsynced unless we do it through Stack Auth's API.