### PR TITLE
feat: add segment analytics with optout and backend as proxy

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -27,6 +27,7 @@
     "@octokit/app": "14.0.0",
     "@octokit/auth-app": "5.0.0",
     "@octokit/rest": "20.0.0",
+    "@segment/analytics-node": "^2.2.1",
     "@stackframe/stack": "2.8.11",
     "aws-sdk": "2.1692.0",
     "better-sse": "0.14.1",

--- a/apps/backend/src/apps/analytics-events.ts
+++ b/apps/backend/src/apps/analytics-events.ts
@@ -1,0 +1,44 @@
+import type { AnalyticsEventBody } from '@appdotbuild/core';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import Analytics from '@segment/analytics-node';
+
+export async function sendAnalyticsEvent(
+  request: FastifyRequest<{ Body: AnalyticsEventBody }>,
+  reply: FastifyReply,
+) {
+  try {
+    const segmentAdapter = new Analytics({
+      writeKey: process.env.SEGMENT_WRITE_KEY || '',
+    });
+
+    const userId = request.user?.id || 'anonymous';
+    const event = request.body;
+
+    const { eventType, eventName } = event;
+
+    if (eventType === 'identify') {
+      segmentAdapter.identify({ userId: userId });
+      return reply.send(200);
+    }
+
+    if (eventType === 'track' && eventName) {
+      segmentAdapter.track({
+        userId,
+        event: eventName,
+      });
+
+      return reply.send(200);
+    }
+
+    return reply.status(400).send({
+      status: 'error',
+      message: 'Invalid event type or missing event name',
+    });
+  } catch (error) {
+    console.error('Error sending analytics event:', error);
+    return reply.status(500).send({
+      status: 'error',
+      message: 'Internal server error while sending analytics event',
+    });
+  }
+}

--- a/apps/backend/src/apps/analytics-events.ts
+++ b/apps/backend/src/apps/analytics-events.ts
@@ -7,6 +7,8 @@ export async function sendAnalyticsEvent(
   reply: FastifyReply,
 ) {
   try {
+    if (process.env.NODE_ENV !== 'production') return;
+
     const segmentAdapter = new Analytics({
       writeKey: process.env.SEGMENT_WRITE_KEY || '',
     });
@@ -35,7 +37,6 @@ export async function sendAnalyticsEvent(
       message: 'Invalid event type or missing event name',
     });
   } catch (error) {
-    console.error('Error sending analytics event:', error);
     return reply.status(500).send({
       status: 'error',
       message: 'Internal server error while sending analytics event',

--- a/apps/backend/src/github/app.ts
+++ b/apps/backend/src/github/app.ts
@@ -1,6 +1,6 @@
 import { App } from '@octokit/app';
+import type { Options } from '@octokit/app/dist-types/types';
 import { Octokit } from '@octokit/rest';
-import { type Options } from '@octokit/app/dist-types/types';
 
 const APP_ID = Number(process.env.GITHUB_APP_ID);
 const PRIVATE_KEY = process.env.GITHUB_APP_PRIVATE_KEY;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -8,7 +8,9 @@ import {
   listApps,
   postMessage,
 } from './apps';
+import { sendAnalyticsEvent } from './apps/analytics-events';
 import { appHistory } from './apps/app-history';
+import { dockerLoginIfNeeded } from './docker';
 import { isDev, validateEnv } from './env';
 import {
   createOrgInitialCommitEndpoint,
@@ -19,7 +21,6 @@ import {
   userCommitChangesEndpoint,
 } from './github';
 import { logger } from './logger';
-import { dockerLoginIfNeeded } from './docker';
 
 config({ path: '.env' });
 validateEnv();
@@ -61,6 +62,8 @@ app.get('/apps/:id/read-url', authHandler, appByIdUrl);
 
 app.post('/message', authHandler, postMessage);
 app.get('/message-limit', authHandler, getUserMessageLimit);
+
+app.post('/analytics/event', authHandler, sendAnalyticsEvent);
 
 export const start = async () => {
   try {

--- a/apps/cli/src/api/application.ts
+++ b/apps/cli/src/api/application.ts
@@ -1,11 +1,16 @@
 import type { Readable } from 'node:stream';
-import type { AgentSseEvent, App, AppPrompts } from '@appdotbuild/core';
+import type {
+  AgentSseEvent,
+  AnalyticsEventBody,
+  App,
+  AppPrompts,
+} from '@appdotbuild/core';
 import { config } from 'dotenv';
 import { useEnvironmentStore } from '../store/environment-store.js';
-import { apiClient } from './api-client.js';
-import { parseSSE } from './sse.js';
 import { convertPromptsToEvents } from '../utils/convert-prompts-to-events.js';
 import { logger } from '../utils/logger.js';
+import { apiClient } from './api-client.js';
+import { parseSSE } from './sse.js';
 
 // Load environment variables from .env file
 config();
@@ -121,4 +126,14 @@ export async function sendMessage({
     applicationId: applicationId || '',
     traceId: '',
   };
+}
+
+export async function sendEvent({
+  eventType,
+  eventName,
+}: AnalyticsEventBody): Promise<void> {
+  await apiClient.post('/analytics/event', {
+    eventType,
+    eventName,
+  });
 }

--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -1,3 +1,4 @@
+// @ts-strict
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Box, Static, Text } from 'ink';
 import { useEffect } from 'react';
@@ -5,6 +6,7 @@ import { authenticate, ensureIsNeonEmployee } from './auth/auth';
 import { useAuth } from './auth/use-auth';
 import { Banner } from './components/ui/Banner';
 import { DebugPanel } from './debug/debugger-panel';
+import { useAnalytics } from './hooks/use-analytics';
 import { AppRouter } from './routes';
 
 const queryClient = new QueryClient();
@@ -34,6 +36,7 @@ export const App = () => {
 
 function AuthWrapper({ children }: { children: React.ReactNode }) {
   const { data, error, isLoading } = useAuth();
+  const { trackEvent } = useAnalytics();
   const isAuthenticated = !isLoading && !!data?.isLoggedIn;
 
   useEffect(() => {
@@ -42,8 +45,13 @@ function AuthWrapper({ children }: { children: React.ReactNode }) {
     } else {
       // ensure the user is a neon employee
       void ensureIsNeonEmployee();
+
+      // track identify event when user is authenticated
+      trackEvent({
+        eventType: 'identify',
+      });
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, trackEvent]);
 
   let content = null;
 

--- a/apps/cli/src/app/app-home-screen.tsx
+++ b/apps/cli/src/app/app-home-screen.tsx
@@ -1,6 +1,8 @@
 import { Box, Text } from 'ink';
 import { Select } from '../components/shared/input/select.js';
 import { type RoutePath, useSafeNavigate } from '../routes.js';
+import { useAnalytics } from '../hooks/use-analytics.js';
+import { AnalyticsEvents } from '@appdotbuild/core';
 
 const items = [
   { label: '🆕 Create new app', value: '/app/build' as const },
@@ -18,6 +20,7 @@ const items = [
 }>;
 
 export function AppHomeScreen() {
+  const { trackEvent } = useAnalytics();
   const { safeNavigate } = useSafeNavigate();
 
   return (
@@ -29,6 +32,16 @@ export function AppHomeScreen() {
         question="What would you like to do?"
         options={items}
         onSubmit={(value) => {
+          trackEvent({
+            eventType: 'track',
+            eventName:
+              value === '/app/build'
+                ? AnalyticsEvents.NEW_APP_SELECTED
+                : value === '/apps'
+                ? AnalyticsEvents.APPS_LISTED
+                : undefined,
+          });
+
           safeNavigate({ path: value });
         }}
       />

--- a/apps/cli/src/app/apps-list-screen.tsx
+++ b/apps/cli/src/app/apps-list-screen.tsx
@@ -1,10 +1,11 @@
-import type { App } from '@appdotbuild/core';
+import { AnalyticsEvents, type App } from '@appdotbuild/core';
 import { Box, Text } from 'ink';
 import { LoadingMessage } from '../components/shared/display/loading-message.js';
 import { Select } from '../components/shared/input/select.js';
 import type { SelectItem } from '../components/shared/input/types.js';
 import { useListApps } from '../hooks/use-application.js';
 import { useSafeNavigate } from '../routes.js';
+import { useAnalytics } from '../hooks/use-analytics.js';
 
 export const getStatusEmoji = (status?: string | null): string => {
   switch (status) {
@@ -43,6 +44,7 @@ export const AppsListScreen = () => {
   const { safeNavigate } = useSafeNavigate();
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetching } =
     useListApps();
+  const { trackEvent } = useAnalytics();
 
   const apps = data?.pages.flatMap((page) => page.data);
 
@@ -87,6 +89,10 @@ export const AppsListScreen = () => {
         question="Select an application to iterate on:"
         options={items}
         onSubmit={(item) => {
+          trackEvent({
+            eventType: 'track',
+            eventName: AnalyticsEvents.APP_SELECTED,
+          });
           safeNavigate({
             path: '/apps/:appId',
             params: { appId: item },

--- a/apps/cli/src/auth/auth.ts
+++ b/apps/cli/src/auth/auth.ts
@@ -62,7 +62,7 @@ export async function fetchAccessToken(refreshToken: string): Promise<{
   };
 }
 
-export async function authenticate(): Promise<string> {
+export async function authenticate(onAuthOpened?: () => void): Promise<string> {
   // Check if we already have a valid access token
   const accessToken = tokenStorage.getAccessToken();
   if (accessToken) {
@@ -100,12 +100,13 @@ export async function authenticate(): Promise<string> {
     // @ts-expect-error - method exists, but types don't reflect it.
     promptLink: (url: string) => {
       logger.link('💻 🔗 Opening auth link in your default browser:', url);
+      onAuthOpened?.();
       open(url);
     },
   });
 
   if (newRefreshTokenResponse.status === 'error') {
-    throw new Error('Authentication failed: ' + newRefreshTokenResponse.error);
+    throw new Error(`Authentication failed: ${newRefreshTokenResponse.error}`);
   }
 
   const newAccessToken = await fetchAccessToken(newRefreshTokenResponse.data);

--- a/apps/cli/src/cli.tsx
+++ b/apps/cli/src/cli.tsx
@@ -6,6 +6,7 @@ import {
   type Environment,
   useEnvironmentStore,
 } from './store/environment-store.js';
+import { useAnalyticsStore } from './store/analytics-store.js';
 
 // in the CLI, node_env is only production or development
 const defaultEnv = process.env.NODE_ENV ?? 'development';
@@ -31,6 +32,11 @@ const cli = meow(
         default: defaultEnv,
         choices: ['staging', 'production', 'development'],
       },
+      analytics: {
+        type: 'boolean',
+        default: true,
+        description: 'Manage analytics. Example: --analytics false',
+      },
     },
   },
 );
@@ -40,5 +46,8 @@ clearTerminal();
 
 // Set the environment for the agent
 useEnvironmentStore.getState().setEnvironment(cli.flags.env as Environment);
+
+// Set analytics preference
+useAnalyticsStore.getState().setAnalyticsEnabled(cli.flags.analytics);
 
 render(<App />);

--- a/apps/cli/src/components/chat/terminal-chat.tsx
+++ b/apps/cli/src/components/chat/terminal-chat.tsx
@@ -1,4 +1,4 @@
-import { MessageKind } from '@appdotbuild/core';
+import { AnalyticsEvents, MessageKind } from '@appdotbuild/core';
 import { Box, Static } from 'ink';
 import { useEffect, useState } from 'react';
 import { useApplicationHistory } from '../../hooks/use-application';
@@ -16,6 +16,7 @@ import { LoadingMessage } from '../shared/display/loading-message';
 import { TerminalInput } from './terminal-input';
 import { TerminalLoading } from './terminal-loading';
 import { TerminalMessage } from './terminal-message';
+import { useAnalytics } from '../../hooks/use-analytics';
 
 export function TerminalChat({
   initialPrompt,
@@ -30,6 +31,8 @@ export function TerminalChat({
   const [staticMessages, setStaticMessages] = useState<Message[]>([]);
   const [hasLoadedHistory, setHasLoadedHistory] = useState(false);
   const [processedEventCount, setProcessedEventCount] = useState(0);
+
+  const { trackEvent } = useAnalytics();
 
   const { isLoading: isLoadingHistory, data: historyMessages } =
     useApplicationHistory(appId);
@@ -46,6 +49,15 @@ export function TerminalChat({
 
   const { userMessageLimit, isUserReachedMessageLimit } =
     useUserMessageLimitCheck(createApplicationError);
+
+  useEffect(() => {
+    if (isUserReachedMessageLimit) {
+      trackEvent({
+        eventType: 'track',
+        eventName: AnalyticsEvents.DAILY_LIMIT_REACHED,
+      });
+    }
+  }, [trackEvent, isUserReachedMessageLimit]);
 
   const { isLoading: isLoadingMessageLimit } = useFetchMessageLimit();
 

--- a/apps/cli/src/entrypoint.ts
+++ b/apps/cli/src/entrypoint.ts
@@ -8,11 +8,7 @@ const currentVersion = parseInt(process.version.substring(1).split('.')[0], 10);
 
 if (currentVersion < requiredVersion) {
   console.error(
-    '\x1b[31mError: Node.js ' +
-      requiredVersion +
-      '+ is required. You are using' +
-      process.version +
-      '.\x1b[0m',
+    `\x1b[31mError: Node.js ${requiredVersion}+ is required. You are using${process.version}.\x1b[0m`,
   );
   console.error(
     '\x1b[31mPlease upgrade your Node.js version and try again.\x1b[0m',

--- a/apps/cli/src/hooks/use-analytics.ts
+++ b/apps/cli/src/hooks/use-analytics.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+import { sendEvent } from '../api/application';
+import type { AnalyticsEvents, AnalyticsEventType } from '@appdotbuild/core';
+import { useAnalyticsStore } from '../store/analytics-store';
+
+export const useAnalytics = () => {
+  const { mutate } = useMutation({
+    mutationFn: async ({
+      eventType,
+      eventName,
+    }: {
+      eventType: AnalyticsEventType;
+      eventName?: AnalyticsEvents;
+    }) => {
+      const isAnalyticsEnabled = useAnalyticsStore.getState().analyticsEnabled;
+      if (!isAnalyticsEnabled) return;
+
+      if (!eventType) throw new Error('Event type and name are required');
+      if (eventType === 'track' && !eventName)
+        throw new Error('Event name is required for tracking');
+
+      return await sendEvent({
+        eventType,
+        eventName,
+      });
+    },
+  });
+
+  return {
+    trackEvent: mutate,
+  };
+};

--- a/apps/cli/src/hooks/use-message-limit.ts
+++ b/apps/cli/src/hooks/use-message-limit.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
-import type { UserMessageLimit } from '@appdotbuild/core';
+import { AnalyticsEvents, type UserMessageLimit } from '@appdotbuild/core';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../api/api-client';
+import { useAnalytics } from './use-analytics';
 
 export const MESSAGE_LIMIT_ERROR_TYPE = 'MESSAGE_LIMIT_ERROR';
 

--- a/apps/cli/src/store/analytics-store.ts
+++ b/apps/cli/src/store/analytics-store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface AnalyticsState {
+  analyticsEnabled: boolean;
+  setAnalyticsEnabled: (enabled: boolean) => void;
+}
+
+export const useAnalyticsStore = create<AnalyticsState>((set) => ({
+  analyticsEnabled: true,
+  setAnalyticsEnabled: (enabled) => set({ analyticsEnabled: enabled }),
+}));

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "@octokit/app": "14.0.0",
         "@octokit/auth-app": "5.0.0",
         "@octokit/rest": "20.0.0",
+        "@segment/analytics-node": "^2.2.1",
         "@stackframe/stack": "2.8.11",
         "aws-sdk": "2.1692.0",
         "better-sse": "0.14.1",
@@ -976,6 +977,10 @@
 
     "@lezer/lr": ["@lezer/lr@1.4.2", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA=="],
 
+    "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
+
+    "@lukeed/uuid": ["@lukeed/uuid@2.0.1", "", { "dependencies": { "@lukeed/csprng": "^1.1.0" } }, "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w=="],
+
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.0", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
@@ -1285,6 +1290,12 @@
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.11.0", "", {}, "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ=="],
+
+    "@segment/analytics-core": ["@segment/analytics-core@1.8.1", "", { "dependencies": { "@lukeed/uuid": "^2.0.0", "@segment/analytics-generic-utils": "1.2.0", "dset": "^3.1.4", "tslib": "^2.4.1" } }, "sha512-EYcdBdhfi1pOYRX+Sf5orpzzYYFmDHTEu6+w0hjXpW5bWkWct+Nv6UJg1hF4sGDKEQjpZIinLTpQ4eioFM4KeQ=="],
+
+    "@segment/analytics-generic-utils": ["@segment/analytics-generic-utils@1.2.0", "", { "dependencies": { "tslib": "^2.4.1" } }, "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw=="],
+
+    "@segment/analytics-node": ["@segment/analytics-node@2.2.1", "", { "dependencies": { "@lukeed/uuid": "^2.0.0", "@segment/analytics-core": "1.8.1", "@segment/analytics-generic-utils": "1.2.0", "buffer": "^6.0.3", "jose": "^5.1.0", "node-fetch": "^2.6.7", "tslib": "^2.4.1" } }, "sha512-J+p5r2BewzowI6YsnSH6U+W9IAvRbEyheqDOSUEwh6QDbxjwcBXwzuPwtz5DtEjbEGMu2QwrwoJvZlZ/n5fugw=="],
 
     "@semantic-release/changelog": ["@semantic-release/changelog@6.0.0", "", { "dependencies": { "@semantic-release/error": "^2.1.0", "aggregate-error": "^3.0.0", "fs-extra": "^9.0.0", "lodash": "^4.17.4" }, "peerDependencies": { "semantic-release": ">=18.0.0" } }, "sha512-X01Me+QVMykvILockNGlXXl3dgr1QqpbRQsknQoOJQCXQGXoqY3DNQ3rBQuI8/SUK7RZwYLctg0NbPNArlo6eQ=="],
 
@@ -1932,7 +1943,7 @@
 
     "btoa-lite": ["btoa-lite@1.0.0", "", {}, "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="],
 
-    "buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -2263,6 +2274,8 @@
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
     "drizzle-orm": ["drizzle-orm@0.39.0", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-kkZwo3Jvht0fdJD/EWGx0vYcEK0xnGrlNVaY07QYluRZA9N21B9VFbY+54bnb/1xvyzcg97tE65xprSAP/fFGQ=="],
+
+    "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -4946,6 +4959,10 @@
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.0", "", { "dependencies": { "@radix-ui/react-slot": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw=="],
 
+    "@segment/analytics-node/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "@segment/analytics-node/node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
+
     "@semantic-release/exec/@semantic-release/error": ["@semantic-release/error@3.0.0", "", {}, "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="],
 
     "@semantic-release/git/@semantic-release/error": ["@semantic-release/error@3.0.0", "", {}, "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="],
@@ -5190,6 +5207,8 @@
 
     "assistant-stream/nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
 
+    "aws-sdk/buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
+
     "aws-sdk/uuid": ["uuid@8.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -5221,6 +5240,8 @@
     "browserify-sign/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "browserify-sign/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "buffer/ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "camelcase-keys/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
@@ -5468,8 +5489,6 @@
 
     "inquirer/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "it-to-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "it-to-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -5527,8 +5546,6 @@
     "node-plop/inquirer": ["inquirer@7.3.3", "", { "dependencies": { "ansi-escapes": "^4.2.1", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-width": "^3.0.0", "external-editor": "^3.0.3", "figures": "^3.0.0", "lodash": "^4.17.19", "mute-stream": "0.0.8", "run-async": "^2.4.0", "rxjs": "^6.6.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0", "through": "^2.3.6" } }, "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA=="],
 
     "node-plop/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
-
-    "node-polyfill-webpack-plugin/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "node-polyfill-webpack-plugin/events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -7116,8 +7133,6 @@
 
     "inquirer/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "it-to-stream/buffer/ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
     "lint-staged/execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
     "lint-staged/execa/human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
@@ -7169,8 +7184,6 @@
     "node-plop/inquirer/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "node-plop/inquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "node-polyfill-webpack-plugin/buffer/ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "node-polyfill-webpack-plugin/url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
@@ -7317,8 +7330,6 @@
     "signale/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "signale/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "stdin-discarder/bl/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "stdin-discarder/bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -8365,8 +8376,6 @@
     "signale/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "signale/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "stdin-discarder/bl/buffer/ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "sucrase/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1553,7 +1553,7 @@
 
     "@types/btoa-lite": ["@types/btoa-lite@1.0.2", "", {}, "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="],
 
-    "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+    "@types/bun": ["@types/bun@1.2.16", "", { "dependencies": { "bun-types": "1.2.16" } }, "sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ=="],
 
     "@types/conventional-commits-parser": ["@types/conventional-commits-parser@5.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ=="],
 
@@ -1959,7 +1959,7 @@
 
     "bun": ["bun@1.2.5", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.2.5", "@oven/bun-darwin-x64": "1.2.5", "@oven/bun-darwin-x64-baseline": "1.2.5", "@oven/bun-linux-aarch64": "1.2.5", "@oven/bun-linux-aarch64-musl": "1.2.5", "@oven/bun-linux-x64": "1.2.5", "@oven/bun-linux-x64-baseline": "1.2.5", "@oven/bun-linux-x64-musl": "1.2.5", "@oven/bun-linux-x64-musl-baseline": "1.2.5", "@oven/bun-windows-x64": "1.2.5", "@oven/bun-windows-x64-baseline": "1.2.5" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bun.exe" } }, "sha512-fbQLt+DPiGUrPKdmsHRRT7cQAlfjdxPVFvLZrsUPmKiTdv+pU50ypdx9yRJluknSbyaZchFVV7Lx2KXikXKX2Q=="],
 
-    "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+    "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -5535,6 +5535,8 @@
 
     "minimist-options/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 
+    "mocked-agent/@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+
     "mocked-agent/fastify": ["fastify@5.3.3", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.0", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.0.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-nCBiBCw9q6jPx+JJNVgO8JVnTXeUyrGcyTKPQikRkA/PanrFcOIo4R+ZnLeOLPZPGgzjomqfVarzE0kYx7qWiQ=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
@@ -7162,6 +7164,8 @@
     "mdast-util-mdx-jsx/parse-entities/is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "mocked-agent/@types/bun/bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 
     "mocked-agent/fastify/secure-json-parse": ["secure-json-parse@4.0.0", "", {}, "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA=="],
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -14,3 +14,4 @@ export class UnauthorizedError extends UserError {}
 export * from './agent-message';
 export * from './types/api';
 export * from './types/utils';
+export * from './types/analytics';

--- a/packages/core/types/analytics.ts
+++ b/packages/core/types/analytics.ts
@@ -1,0 +1,23 @@
+export const AnalyticsEventType = {
+  IDENTIFY: 'identify',
+  TRACK: 'track',
+} as const;
+
+export type AnalyticsEventType =
+  (typeof AnalyticsEventType)[keyof typeof AnalyticsEventType];
+
+export type AnalyticsEvents =
+  (typeof AnalyticsEvents)[keyof typeof AnalyticsEvents];
+
+export type AnalyticsEventBody = {
+  eventType: AnalyticsEventType;
+  eventName?: AnalyticsEvents;
+};
+
+export const AnalyticsEvents = {
+  APPS_LISTED: 'apps_listed',
+  APP_SELECTED: 'app_selected',
+  NEW_APP_SELECTED: 'new_app_selected',
+
+  DAILY_LIMIT_REACHED: 'daily_limit_reached',
+} as const;

--- a/scripts/templates/.env.backend.example
+++ b/scripts/templates/.env.backend.example
@@ -22,3 +22,5 @@ GITHUB_APP_PRIVATE_KEY='op://App.build/GITHUB_APP_PRIVATE_KEY/private key'
 GITHUB_APP_BOT_EMAIL='op://App.build/GITHUB_APP_BOT_EMAIL/credential'
 KOYEB_CLI_PAT_TOKEN='op://App.build/KOYEB_CLI_PAT_TOKEN/credential'
 DATABASE_URL_DEV="op://App.build/DATABASE_URL_$USERNAME/credential"
+DAILY_MESSAGE_LIMIT='op://App.build/DAILY_MESSAGE_LIMIT/credential'
+SEGMENT_WRITE_KEY='op://App.build/SEGMENT_WRITE_KEY/credential'


### PR DESCRIPTION
#36 
Analytics implementation:

- A small number of events that can give us more context about the usage.
- The backend is used as a proxy to prevent the write key from being exposed.
- Segment SDK integration
- Scalable implementation to quickly add new events when necessary.