### PR TITLE
feat: adds databricks CLI to the backend docker image

### DIFF
--- a/apps/backend/Dockerfile.backend
+++ b/apps/backend/Dockerfile.backend
@@ -58,6 +58,13 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh /usr/local/bin/docker-entrypoi
 
 VOLUME /var/lib/docker
 
+# Install Databricks CLI
+RUN curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+
+# Install jq
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y jq
+
 COPY --from=build /appdotbuild /appdotbuild
 COPY --from=build /root /root
 

--- a/apps/backend/src/apps/message.ts
+++ b/apps/backend/src/apps/message.ts
@@ -320,6 +320,7 @@ export async function postMessage(
         ...body,
         applicationId,
         traceId,
+        templateId: 'nicegui_agent',
       };
     }
 
@@ -684,6 +685,7 @@ export async function postMessage(
                   deployApp({
                     appId: applicationId!,
                     appDirectory: tempDirPath,
+                    databricksMode: Boolean(requestBody.databricksHost),
                   }),
                 )
                 .catch(async (error) => {

--- a/apps/backend/src/deploy/deploy-app.ts
+++ b/apps/backend/src/deploy/deploy-app.ts
@@ -36,9 +36,11 @@ const neonClient = createApiClient({
 export async function deployApp({
   appId,
   appDirectory,
+  databricksMode,
 }: {
   appId: string;
   appDirectory: string;
+  databricksMode: boolean;
 }) {
   const app = await db
     .select({
@@ -49,6 +51,8 @@ export async function deployApp({
       koyebAppId: apps.koyebAppId,
       koyebServiceId: apps.koyebServiceId,
       koyebDomainId: apps.koyebDomainId,
+      databricksApiKey: apps.databricksApiKey,
+      databricksHost: apps.databricksHost,
     })
     .from(apps)
     .where(eq(apps.id, appId));
@@ -62,6 +66,87 @@ export async function deployApp({
   // deployed is okay, but deploying is not
   if (currentApp.deployStatus === 'deploying') {
     throw new Error(`App ${appId} is already being deployed`);
+  }
+
+  // If we are deploying to databricks, we need to import the code into the databricks workspace
+  // and then deploy the app from there. We use the databricks CLI to do this.
+  if (databricksMode) {
+    if (!currentApp.databricksApiKey || !currentApp.databricksHost) {
+      throw new Error(
+        'Databricks API key and host are required for Databricks deployment',
+      );
+    }
+
+    // Set Databricks CLI environment variables
+    process.env.DATABRICKS_HOST = currentApp.databricksHost;
+    process.env.DATABRICKS_TOKEN = currentApp.databricksApiKey;
+
+    // Generate a unique workspace path for this app
+    const workspacePath = `/Workspace/Users/david.gomes@databricks.com/nice_gui_example`;
+
+    logger.info('Starting Databricks deployment', {
+      appId,
+      workspacePath,
+      databricksHost: currentApp.databricksHost,
+    });
+
+    try {
+      // 1. Import the code into the databricks workspace
+      logger.info('Importing code to Databricks workspace');
+      await exec(
+        `databricks workspace import-dir --overwrite "${appDirectory}" "/Users/david.gomes@databricks.com/nice_gui_example"`,
+        {
+          cwd: appDirectory,
+        },
+      );
+
+      // 2. Deploy the app from there
+      logger.info('Deploying app to Databricks');
+      const deployResult = await exec(
+        `databricks apps deploy app-${appId} --source-code-path "/Workspace${workspacePath}"`,
+        {
+          cwd: appDirectory,
+        },
+      );
+
+      logger.info('Databricks deployment completed', {
+        appId,
+        deployOutput: deployResult.stdout,
+      });
+
+      // Update app status to deployed
+      await db
+        .update(apps)
+        .set({
+          deployStatus: 'deployed',
+          appUrl: `${currentApp.databricksHost}/#workspace${workspacePath}`,
+        })
+        .where(eq(apps.id, appId));
+
+      return {
+        appURL: `${currentApp.databricksHost}/#workspace${workspacePath}`,
+        deploymentId: `databricks-${appId}`,
+      };
+    } catch (error) {
+      logger.error('Databricks deployment failed', {
+        appId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // Update app status to failed
+      await db
+        .update(apps)
+        .set({
+          deployStatus: 'failed',
+        })
+        .where(eq(apps.id, appId));
+
+      throw new Error(
+        `Databricks deployment failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   let connectionString: string | undefined;


### PR DESCRIPTION
```
~/s/a/platform ❯❯❯ ./scripts/docker-build.sh                                            docker-image-backend-databricks ◼
[+] Building 154.1s (39/39) FINISHED                                                                 docker:desktop-linux
 => [internal] load build definition from Dockerfile.backend                                                         0.0s
 => => transferring dockerfile: 2.99kB                                                                               0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                            3.9s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                     0.0s
 => docker-image://docker.io/docker/dockerfile:1@sha256:9857836c9ee4268391bb5b09f9f157f3c91bb15821bb77969642813b0d0  1.9s
 => => resolve docker.io/docker/dockerfile:1@sha256:9857836c9ee4268391bb5b09f9f157f3c91bb15821bb77969642813b0d00518  0.0s
 => => sha256:aaaa2ba5fc0bfa9eaf9d2e1ab46b7ebaf83587ddf0752c9240f5413c3a11cd0d 12.38MB / 12.38MB                     1.8s
 => => extracting sha256:aaaa2ba5fc0bfa9eaf9d2e1ab46b7ebaf83587ddf0752c9240f5413c3a11cd0d                            0.1s
 => [internal] load metadata for docker.io/oven/bun:1.2.8-slim                                                       2.7s
 => [internal] load metadata for docker.io/library/docker:dind                                                       2.9s
 => [auth] oven/bun:pull token for registry-1.docker.io                                                              0.0s
 => [auth] library/docker:pull token for registry-1.docker.io                                                        0.0s
 => [internal] load .dockerignore                                                                                    0.0s
 => => transferring context: 2B                                                                                      0.0s
 => FROM docker.io/library/docker:dind@sha256:d33eb93fe02683e984e6f8a93c0b3d85bb74f56ec83922bc39fb34ba23ab42bc      14.2s
 => => resolve docker.io/library/docker:dind@sha256:d33eb93fe02683e984e6f8a93c0b3d85bb74f56ec83922bc39fb34ba23ab42b  0.0s
 => => sha256:1dc224144c04ef3481a0325fe0397605a96a0b2cc32a11f2bb51ff0f02cf3b18 3.30kB / 3.30kB                       0.4s
 => => sha256:5409164ad4fffce29827dfd0997d723d4acbb80a4db2c10cae16882640caf580 1.69kB / 1.69kB                       0.4s
 => => sha256:f2c07753a1e7611acc40ff993b6bb77ee28e1c38d51232fad653499eab0b852e 57.46MB / 57.46MB                    12.0s
 => => sha256:deace05d4e2463a7802c79c319cc8c0efec0da8e7e7d0e3fc50cb892300e9202 1.01kB / 1.01kB                       1.3s
 => => sha256:60f38badf3f4309571b4ba9b63d0081039a46caa66d30e139be5a99b3246f837 99.65kB / 99.65kB                     0.6s
 => => sha256:e26e288846779cb65a12fa9317a7d0b83901dc1fc974c4897d70d99298b6d554 7.14MB / 7.14MB                       1.7s
 => => sha256:bbe8bd6221f77de746989b8fb7c2fd18258ebe95bed0552e77da29f8bfb7b283 1.01kB / 1.01kB                       1.0s
 => => sha256:2282c032f942aa616f0cf5d86e61b242a81cb9a5dbc3501a625ac9011a60bd97 116B / 116B                           0.4s
 => => sha256:8a6a465a1f82d236a77e9d56a61a47a52f485772e7b3f15e106ce33e9c0122cc 537B / 537B                           0.4s
 => => sha256:0d06e85c1279ded07aa91a88084a5150f5cd8d2548264b21d31466a83fd0efbe 19.82MB / 19.82MB                     2.6s
 => => sha256:ce2b960b1bcb756bfb47a9d30ccd9d833fa804cd1937e49192e352282b3052fd 19.49MB / 19.49MB                     8.0s
 => => sha256:6a8fd166aa06a91e8aebc25ae41e6d6cc5e7c28d6ed8d80900bbbff954c25039 19.27MB / 19.27MB                     5.3s
 => => sha256:d76080ff7919b6f2f983bad6e60d90dd09fe89ae23d5d4b1902e2401d5bdb4c3 457B / 457B                           0.4s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                             0.4s
 => => sha256:1efdbf9d870140ba6962f37fb5c88bd7ff5a6edbecc246ad72a2fa05bf931215 8.23MB / 8.23MB                       1.6s
 => => sha256:d69d4d41cfe2ee680d6972795e2a1eb9e4dc4ec3b3c5e0797c9ab43bb3726fa7 4.14MB / 4.14MB                       0.7s
 => => extracting sha256:d69d4d41cfe2ee680d6972795e2a1eb9e4dc4ec3b3c5e0797c9ab43bb3726fa7                            0.0s
 => => extracting sha256:1efdbf9d870140ba6962f37fb5c88bd7ff5a6edbecc246ad72a2fa05bf931215                            0.1s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                            0.0s
 => => extracting sha256:d76080ff7919b6f2f983bad6e60d90dd09fe89ae23d5d4b1902e2401d5bdb4c3                            0.0s
 => => extracting sha256:6a8fd166aa06a91e8aebc25ae41e6d6cc5e7c28d6ed8d80900bbbff954c25039                            0.1s
 => => extracting sha256:0d06e85c1279ded07aa91a88084a5150f5cd8d2548264b21d31466a83fd0efbe                            0.2s
 => => extracting sha256:ce2b960b1bcb756bfb47a9d30ccd9d833fa804cd1937e49192e352282b3052fd                            0.2s
 => => extracting sha256:8a6a465a1f82d236a77e9d56a61a47a52f485772e7b3f15e106ce33e9c0122cc                            0.0s
 => => extracting sha256:bbe8bd6221f77de746989b8fb7c2fd18258ebe95bed0552e77da29f8bfb7b283                            0.0s
 => => extracting sha256:2282c032f942aa616f0cf5d86e61b242a81cb9a5dbc3501a625ac9011a60bd97                            0.0s
 => => extracting sha256:e26e288846779cb65a12fa9317a7d0b83901dc1fc974c4897d70d99298b6d554                            0.1s
 => => extracting sha256:60f38badf3f4309571b4ba9b63d0081039a46caa66d30e139be5a99b3246f837                            0.0s
 => => extracting sha256:deace05d4e2463a7802c79c319cc8c0efec0da8e7e7d0e3fc50cb892300e9202                            0.0s
 => => extracting sha256:f2c07753a1e7611acc40ff993b6bb77ee28e1c38d51232fad653499eab0b852e                            0.4s
 => => extracting sha256:5409164ad4fffce29827dfd0997d723d4acbb80a4db2c10cae16882640caf580                            0.0s
 => => extracting sha256:1dc224144c04ef3481a0325fe0397605a96a0b2cc32a11f2bb51ff0f02cf3b18                            0.0s
 => [internal] load build context                                                                                    1.1s
 => => transferring context: 43.58MB                                                                                 1.1s
 => [stage-2  5/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/docker-entrypoint.sh /usr/lo  0.7s
 => [stage-2  6/13] ADD https://raw.githubusercontent.com/moby/moby/master/hack/dind /usr/local/bin/dind             0.7s
 => [stage-2  7/13] ADD https://raw.githubusercontent.com/koyeb/koyeb-docker-compose/refs/heads/master/koyeb-entryp  0.7s
 => [stage-2  3/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/modprobe.sh /usr/local/bin/m  0.7s
 => [stage-2  4/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/dockerd-entrypoint.sh /usr/l  0.8s
 => [base 1/3] FROM docker.io/oven/bun:1.2.8-slim@sha256:c98a718b04ad141df050a8e08833a5d2d2b5a356bf3ef8c8695febdeff  5.7s
 => => resolve docker.io/oven/bun:1.2.8-slim@sha256:c98a718b04ad141df050a8e08833a5d2d2b5a356bf3ef8c8695febdeffb8381  0.0s
 => => sha256:0e4d03b00b87fb9939a6ab84160dea6ad2bfce6d3650080135f27e2ac773b3da 137B / 137B                           0.4s
 => => sha256:8fd8aae87b565f87cfc24ff90848263583c72b3100fb4907cd4beb570195fb89 4.15kB / 4.15kB                       0.6s
 => => sha256:9b5523844df692f74b02a295398ee581325d4ba48e9b0d28f7cb895e9f6f6f4e 184B / 184B                           0.8s
 => => sha256:2662f715523fbb82b64b8ff73f9d95d47c6d9dfa4bdbdf828f649851ffd54301 37.94MB / 37.94MB                     4.2s
 => => sha256:d93fc4a8cbb5f40e80462abe4045e6d21151e51c79790531507486679bd74358 295B / 295B                           0.9s
 => => sha256:6eba8885c82049d690776150810f32585aca6c3eba49f692753434bdaee447ec 28.75MB / 28.75MB                     4.3s
 => => extracting sha256:6eba8885c82049d690776150810f32585aca6c3eba49f692753434bdaee447ec                            0.4s
 => => extracting sha256:d93fc4a8cbb5f40e80462abe4045e6d21151e51c79790531507486679bd74358                            0.0s
 => => extracting sha256:2662f715523fbb82b64b8ff73f9d95d47c6d9dfa4bdbdf828f649851ffd54301                            0.3s
 => => extracting sha256:9b5523844df692f74b02a295398ee581325d4ba48e9b0d28f7cb895e9f6f6f4e                            0.0s
 => => extracting sha256:8fd8aae87b565f87cfc24ff90848263583c72b3100fb4907cd4beb570195fb89                            0.0s
 => => extracting sha256:0e4d03b00b87fb9939a6ab84160dea6ad2bfce6d3650080135f27e2ac773b3da                            0.0s
 => [base 2/3] WORKDIR /appdotbuild                                                                                  0.1s
 => [base 3/3] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y ca-certificates curl gnupg  40.6s
 => [build 1/6] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y build-essential pkg-confi  29.7s
 => [stage-2  1/13] RUN mkdir -pm755 /etc/apt/keyrings && curl -o /etc/apt/keyrings/docker.asc -fsSL "https://down  16.8s
 => [stage-2  2/13] COPY --from=docker:dind /usr/local/bin/docker-init /usr/local/bin/docker-init                    0.0s
 => [stage-2  3/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/modprobe.sh /usr/local/bin/m  0.0s
 => [stage-2  4/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/dockerd-entrypoint.sh /usr/l  0.0s
 => [stage-2  5/13] ADD https://raw.githubusercontent.com/docker-library/docker/master/docker-entrypoint.sh /usr/lo  0.0s
 => [stage-2  6/13] ADD https://raw.githubusercontent.com/moby/moby/master/hack/dind /usr/local/bin/dind             0.0s
 => [stage-2  7/13] ADD https://raw.githubusercontent.com/koyeb/koyeb-docker-compose/refs/heads/master/koyeb-entryp  0.0s
 => [stage-2  8/13] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh /usr/local/bin/docker-entrypoint.sh /usr/loca  0.1s
 => [stage-2  9/13] RUN curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh       6.1s
 => [stage-2 10/13] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y jq                      8.1s
 => [build 2/6] RUN curl -fsSL https://raw.githubusercontent.com/koyeb/koyeb-cli/master/install.sh | sh              5.2s
 => [build 3/6] COPY bun.lock package.json ./                                                                        0.1s
 => [build 4/6] COPY ./apps/backend /appdotbuild/apps/backend                                                        0.6s
 => [build 5/6] COPY ./packages/core /appdotbuild/packages/core                                                      0.0s
 => [build 6/6] RUN bun install --filter "backend"                                                                  23.4s
 => [stage-2 11/13] COPY --from=build /appdotbuild /appdotbuild                                                      3.3s
 => [stage-2 12/13] COPY --from=build /root /root                                                                    3.7s
 => [stage-2 13/13] WORKDIR /appdotbuild                                                                             0.1s
 => exporting to image                                                                                              28.5s
 => => exporting layers                                                                                             16.3s
 => => exporting manifest sha256:474cf24cb76187e0158625c0c37e72357aab7950db96d95fface7a5d4d627ff5                    0.0s
 => => exporting config sha256:cf1fd466770b69cf44761ff9f57c97fe677f60406f586d1f7b1f9ce617e5364d                      0.0s
 => => exporting attestation manifest sha256:f12039c99a1a24de8371a371192081819ae511993d97d2df6a3d9d06cd984ddc        0.0s
 => => exporting manifest list sha256:ce5c7c304f9e5eed68e725502a373d8ef0384de6c01ba0da46a61445890a75b8               0.0s
 => => naming to docker.io/appdotbuild/backend:local                                                                 0.0s
 => => unpacking to docker.io/appdotbuild/backend:local                                                             12.2s
~/s/a/platform ❯❯❯                                                                      docker-image-backend-databricks ◼
```