### PR TITLE
feat: add template selection support with --template flag

### DIFF
--- a/apps/backend/src/apps/message.ts
+++ b/apps/backend/src/apps/message.ts
@@ -19,6 +19,7 @@ import {
   StreamingError,
   type TraceId,
   DeployStatus,
+  type TemplateId,
 } from '@appdotbuild/core';
 import { nodeEventSource } from '@llm-eaf/node-event-source';
 import { createSession, type Session } from 'better-sse';
@@ -64,7 +65,7 @@ type Body = {
   settings: Record<string, any>;
   agentState?: any;
   allFiles?: FileData[];
-  templateId?: 'trpc_agent' | 'nicegui_agent';
+  templateId?: TemplateId;
 };
 
 type RequestBody = {
@@ -76,6 +77,7 @@ type RequestBody = {
   traceId?: TraceId;
   databricksApiKey?: string;
   databricksHost?: string;
+  templateId?: TemplateId;
 };
 
 type StructuredLog = {
@@ -217,6 +219,12 @@ export async function postMessage(
       githubAccessToken,
     ).init();
 
+    let templateId = requestBody.templateId || 'trpc_agent';
+    // databricks apps only support python apps for now
+    if (requestBody.databricksHost) {
+      templateId = 'nicegui_agent';
+    }
+
     let body: Optional<Body, 'traceId'> = {
       applicationId,
       allMessages: [
@@ -226,8 +234,7 @@ export async function postMessage(
         },
       ],
       settings: requestBody.settings || {},
-      // for now we only support python apps for databricks apps
-      templateId: requestBody.databricksHost ? 'nicegui_agent' : 'trpc_agent',
+      templateId,
     };
 
     let appName: string | null = null;

--- a/apps/cli/src/api/application.ts
+++ b/apps/cli/src/api/application.ts
@@ -11,6 +11,7 @@ import { convertPromptsToEvents } from '../utils/convert-prompts-to-events.js';
 import { logger } from '../utils/logger.js';
 import { apiClient } from './api-client.js';
 import { parseSSE } from './sse.js';
+import { useFlagsStore } from '../store/flags-store.js';
 
 // Load environment variables from .env file
 config();
@@ -97,6 +98,7 @@ export async function sendMessage({
   signal,
 }: SendMessageParams): Promise<SendMessageResult> {
   const agentEnvironment = useEnvironmentStore.getState().agentEnvironment();
+  const templateId = useFlagsStore.getState().templateId;
 
   const response = await apiClient.post(
     '/message',
@@ -106,6 +108,7 @@ export async function sendMessage({
       applicationId,
       traceId,
       environment: agentEnvironment,
+      templateId,
       databricksApiKey,
       databricksHost,
     },

--- a/apps/cli/src/cli.tsx
+++ b/apps/cli/src/cli.tsx
@@ -7,7 +7,7 @@ import {
   useEnvironmentStore,
 } from './store/environment-store.js';
 import { useAnalyticsStore } from './store/analytics-store.js';
-import { useFlagsStore } from './store/flags-store.js';
+import { TemplateMap, useFlagsStore } from './store/flags-store.js';
 
 // in the CLI, node_env is only production or development
 const defaultEnv = process.env.NODE_ENV ?? 'development';
@@ -19,12 +19,14 @@ const cli = meow(
 
 	Options
 	  --env, -e Agent and platform environment (staging|production) (optional) [default: ${defaultEnv}]
-	  --databricks Enable Databricks app creation mode
+	  --databricks deploy to databricks
+    --template, -t Template to use for app creation (trpc_agent|nicegui_agent) [default: trpc_agent]
 
 	Examples
 	  $ npx @app.build/cli
 	  $ npx @app.build/cli --agent-env staging
 	  $ npx @app.build/cli --databricks
+	  $ npx @app.build/cli --template nicegui_agent
 `,
   {
     importMeta: import.meta,
@@ -45,6 +47,12 @@ const cli = meow(
         default: false,
         description: 'Enable Databricks app creation mode',
       },
+      template: {
+        type: 'string',
+        shortFlag: 't',
+        default: 'trpc-react',
+        choices: ['python', 'trpc-react'],
+      },
     },
   },
 );
@@ -60,5 +68,8 @@ useAnalyticsStore.getState().setAnalyticsEnabled(cli.flags.analytics);
 
 // set databricks mode
 useFlagsStore.getState().setDatabricksMode(cli.flags.databricks);
+
+// set template id
+useFlagsStore.getState().setTemplateId(cli.flags.template as keyof TemplateMap);
 
 render(<App />);

--- a/apps/cli/src/store/flags-store.ts
+++ b/apps/cli/src/store/flags-store.ts
@@ -1,11 +1,25 @@
+import { TemplateId } from '@appdotbuild/core';
 import { create } from 'zustand';
+
+export const templateMap = {
+  python: 'nicegui_agent',
+  'trpc-react': 'trpc_agent',
+} satisfies Record<string, TemplateId>;
+
+export type TemplateMap = typeof templateMap;
 
 interface FlagsStore {
   databricksMode: boolean;
   setDatabricksMode: (mode: boolean) => void;
+
+  templateId: TemplateId;
+  setTemplateId: (templateId: keyof TemplateMap) => void;
 }
 
 export const useFlagsStore = create<FlagsStore>((set) => ({
   databricksMode: false,
   setDatabricksMode: (mode) => set({ databricksMode: mode }),
+
+  templateId: 'trpc_agent',
+  setTemplateId: (templateId) => set({ templateId: templateMap[templateId] }),
 }));

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -71,3 +71,5 @@ export type App = {
   appName?: string | null;
   appUrl?: string | null;
 };
+
+export type TemplateId = 'trpc_agent' | 'nicegui_agent';


### PR DESCRIPTION
## Description

This PR adds template selection support to the CLI, allowing users to choose between different app templates using the new `--template` flag.

**FEATURES**
- Add `--template` flag to CLI with choices: `python` and `trpc-react`
- Map user-friendly template names to internal template IDs (`nicegui_agent` and `trpc_agent`)
- Extend API to accept `templateId` parameter in request body
- Add type safety with proper TypeScript types and template mapping
- Maintain backward compatibility with existing `--databricks` flag behavior

**FIXES**
- Improve template selection logic in backend message handler
- Add proper type exports for `TemplateId` in core package

**BREAKING CHANGES**
- None - all changes are additive and backward compatible

## Test Plan

- [x] CLI accepts `--template python` and `--template trpc-react` flags
- [x] Backend correctly receives and processes templateId parameter
- [x] Default behavior remains unchanged (defaults to `trpc_agent`)
- [x] Databricks mode continues to work as expected
- [ ] Add unit tests for template selection logic
- [ ] Add integration tests for CLI flag combinations
- [ ] Test template mapping validation

🤖 Generated with [Claude Code](https://claude.ai/code)