### PR TITLE
chore: add mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+1password = "latest"
+bun = "1.2.8"
+node = "22.10"


### PR DESCRIPTION
adds support for https://mise.jdx.dev/