### PR TITLE
fix: nicegui apps port override

### DIFF
--- a/apps/backend/src/apps/message.ts
+++ b/apps/backend/src/apps/message.ts
@@ -728,6 +728,7 @@ export async function postMessage(
                     appId: applicationId!,
                     appDirectory: tempDirPath,
                     databricksMode: Boolean(requestBody.databricksHost),
+                    templateId,
                   }),
                 )
                 .catch(async (error) => {


### PR DESCRIPTION
## Description

This PR aims to override the `NICEGUI_PORT` env, to be set to the port 80, so that the Koyeb service can be properly health checked.

**FIXES**
- Sets NICEGUI_PORT environment variable to 80 for nicegui_agent template deployments
- Adds templateId parameter to deployment functions to enable template-specific configuration

