### PR TITLE
fix: missing custom envs on existing service

### DIFF
--- a/apps/backend/src/deploy/koyeb.ts
+++ b/apps/backend/src/deploy/koyeb.ts
@@ -141,11 +141,13 @@ export async function updateKoyebService({
   dockerImage,
   serviceId,
   token,
+  customEnvs,
 }: {
   dockerImage: string;
   databaseUrl: string;
   serviceId: string;
   token: string;
+  customEnvs?: KoyebEnv[];
 }) {
   const response = await fetch(
     `https://app.koyeb.com/v1/services/${serviceId}`,
@@ -158,6 +160,7 @@ export async function updateKoyebService({
         definition: getKoyebServiceBody({
           dockerImage,
           databaseUrl,
+          customEnvs,
         }),
       }),
     },


### PR DESCRIPTION
## Description

This PR aims to fix a bug on deploying `python` apps on iterations. Since we always override the service definition, we need to pass the full definition everytime.