### PR TITLE
feat: add tech stack support to backend

### DIFF
--- a/apps/backend/drizzle/0027_broad_jackal.sql
+++ b/apps/backend/drizzle/0027_broad_jackal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "apps" ADD COLUMN "techStack" text DEFAULT 'trpc_agent' NOT NULL;

--- a/apps/backend/drizzle/meta/0027_snapshot.json
+++ b/apps/backend/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,428 @@
+{
+  "id": "6e81cd70-5008-44eb-89ba-22c01e82e50c",
+  "prevId": "51cf55af-e002-4ccf-a4ef-c9d4e47a6ae7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_prompts": {
+      "name": "app_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_app_prompts_appid_createdat": {
+          "name": "idx_app_prompts_appid_createdat",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_prompts_appId_apps_id_fk": {
+          "name": "app_prompts_appId_apps_id_fk",
+          "tableFrom": "app_prompts",
+          "tableTo": "apps",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppId": {
+          "name": "flyAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3Checksum": {
+          "name": "s3Checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployStatus": {
+          "name": "deployStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "traceId": {
+          "name": "traceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentState": {
+          "name": "agentState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedSuccess": {
+          "name": "receivedSuccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recompileInProgress": {
+          "name": "recompileInProgress",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clientSource": {
+          "name": "clientSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slack'"
+        },
+        "repositoryUrl": {
+          "name": "repositoryUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebAppId": {
+          "name": "koyebAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebServiceId": {
+          "name": "koyebServiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebDomainId": {
+          "name": "koyebDomainId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonProjectId": {
+          "name": "neonProjectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appUrl": {
+          "name": "appUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databricksApiKey": {
+          "name": "databricksApiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databricksHost": {
+          "name": "databricksHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "techStack": {
+          "name": "techStack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trpc_agent'"
+        }
+      },
+      "indexes": {
+        "idx_apps_ownerid_id": {
+          "name": "idx_apps_ownerid_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_message_limits": {
+      "name": "custom_message_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dailyLimit": {
+          "name": "dailyLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_message_limits_userId_unique": {
+          "name": "custom_message_limits_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "appId": {
+          "name": "appId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgId": {
+          "name": "koyebOrgId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgEcrSecretId": {
+          "name": "koyebOrgEcrSecretId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgName": {
+          "name": "koyebOrgName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ownerid": {
+          "name": "idx_ownerid",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_appId_apps_id_fk": {
+          "name": "deployments_appId_apps_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "apps",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1750932381934,
       "tag": "0026_narrow_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1753449825017,
+      "tag": "0027_broad_jackal",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/apps/conversation-manager.ts
+++ b/apps/backend/src/apps/conversation-manager.ts
@@ -4,12 +4,14 @@ import {
   type AgentSseEvent,
   type ApplicationId,
   type ConversationMessage,
+  type TemplateId,
 } from '@appdotbuild/core';
 import { app } from '../app';
 
 export interface ConversationData {
   agentState?: AgentSseEvent['message']['agentState'];
   allMessages: ConversationMessage[];
+  techStack: TemplateId;
 }
 
 export class ConversationManager {
@@ -18,7 +20,11 @@ export class ConversationManager {
   /**
    * Add or update conversation data for an application
    */
-  addConversation(applicationId: string, event: AgentSseEvent): void {
+  addConversation(
+    applicationId: string,
+    event: AgentSseEvent,
+    techStack: TemplateId,
+  ): void {
     const existingConversation = this.conversationMap.get(applicationId);
     let allMessages: ConversationData['allMessages'] = [];
     let agentState: ConversationData['agentState'] = null;
@@ -38,10 +44,15 @@ export class ConversationManager {
     this.conversationMap.set(applicationId, {
       agentState,
       allMessages,
+      techStack: techStack,
     });
   }
 
-  addUserMessageToConversation(applicationId: string, message: string): void {
+  addUserMessageToConversation(
+    applicationId: string,
+    message: string,
+    techStack: TemplateId,
+  ): void {
     const userMessage: ConversationMessage = {
       role: PromptKind.USER,
       content: message,
@@ -56,6 +67,7 @@ export class ConversationManager {
       this.conversationMap.set(applicationId, {
         allMessages: [userMessage],
         agentState: undefined,
+        techStack: techStack,
       });
     }
   }
@@ -63,6 +75,7 @@ export class ConversationManager {
   addMessagesToConversation(
     applicationId: string,
     messages: ConversationMessage[],
+    techStack: TemplateId,
   ): void {
     const existingData = this.conversationMap.get(applicationId);
     if (existingData) {
@@ -72,6 +85,7 @@ export class ConversationManager {
       this.conversationMap.set(applicationId, {
         allMessages: messages,
         agentState: undefined,
+        techStack: techStack,
       });
     }
   }

--- a/apps/backend/src/apps/create-app.ts
+++ b/apps/backend/src/apps/create-app.ts
@@ -9,6 +9,7 @@ import {
 } from '../github';
 import { Instrumentation } from '../instrumentation';
 import type { FileData } from '../utils';
+import type { TemplateId } from '@appdotbuild/core';
 
 export interface CreateAppParams {
   applicationId?: string; // Optional - if not provided, will generate a new one
@@ -21,6 +22,7 @@ export interface CreateAppParams {
   databricksApiKey?: string;
   databricksHost?: string;
   files?: FileData[];
+  techStack: TemplateId;
 }
 
 export interface CreateAppResult {
@@ -44,6 +46,7 @@ export async function createApp({
   agentState,
   databricksApiKey,
   databricksHost,
+  techStack,
   files = [],
 }: CreateAppParams): Promise<CreateAppResult> {
   const applicationId = providedApplicationId || uuidv4();
@@ -111,6 +114,7 @@ export async function createApp({
     githubUsername: githubEntity.githubUsername || null,
     databricksApiKey: databricksApiKey || null,
     databricksHost: databricksHost || null,
+    techStack,
   });
 
   app.log.info({

--- a/apps/backend/src/apps/list.ts
+++ b/apps/backend/src/apps/list.ts
@@ -8,7 +8,9 @@ import { checkMessageUsageLimit } from './message-limit';
 export async function listApps(
   request: FastifyRequest,
   reply: FastifyReply,
-): Promise<Paginated<Pick<App, 'id' | 'appName' | 'name' | 'createdAt'>>> {
+): Promise<
+  Paginated<Pick<App, 'id' | 'appName' | 'name' | 'techStack' | 'createdAt'>>
+> {
   const user = request.user;
 
   const { dailyMessageLimit, nextResetTime, remainingMessages, currentUsage } =
@@ -36,7 +38,7 @@ export async function listApps(
   const pageNum = Math.max(1, Number(page));
   const offset = (pageNum - 1) * pagesize;
 
-  const { id, appName, name, createdAt } = getTableColumns(apps);
+  const { id, appName, name, createdAt, techStack } = getTableColumns(apps);
 
   const countResultP = db
     .select({ count: sql`count(*)` })
@@ -44,7 +46,7 @@ export async function listApps(
     .where(eq(apps.ownerId, user.id));
 
   const appsP = db
-    .select({ id, appName, name, createdAt })
+    .select({ id, appName, name, createdAt, techStack })
     .from(apps)
     .where(eq(apps.ownerId, user.id))
     .orderBy(desc(apps.createdAt))

--- a/apps/backend/src/apps/message.ts
+++ b/apps/backend/src/apps/message.ts
@@ -283,6 +283,7 @@ export async function postMessage(
           'info',
         );
         appName = application[0]!.appName;
+        templateId = application[0]!.techStack as TemplateId;
 
         if (application[0]!.repositoryUrl) {
           githubEntity.repositoryUrl = application[0]!.repositoryUrl;
@@ -297,6 +298,7 @@ export async function postMessage(
         conversationManager.addMessagesToConversation(
           applicationId,
           messagesFromHistory,
+          templateId,
         );
 
         body = {
@@ -324,6 +326,7 @@ export async function postMessage(
         // for temporary apps, we need to get the previous request from the memory
         const existingConversation =
           conversationManager.getConversation(applicationId);
+        templateId = existingConversation?.techStack || templateId;
         if (!existingConversation) {
           streamLog(
             {
@@ -367,6 +370,7 @@ export async function postMessage(
     conversationManager.addUserMessageToConversation(
       applicationId,
       requestBody.message,
+      templateId,
     );
 
     // Save user message to database immediately for permanent apps
@@ -548,6 +552,7 @@ export async function postMessage(
             conversationManager.addConversation(
               applicationId,
               completeParsedMessage,
+              templateId,
             );
 
             // save agent messages to database immediately
@@ -562,6 +567,7 @@ export async function postMessage(
             const parsedCLIMessage = {
               ...completeParsedMessage,
               appId: applicationId,
+              techStack: templateId,
               message: minimalMessage,
             };
 
@@ -696,6 +702,7 @@ export async function postMessage(
 
                 const { newAppName } = await appCreation({
                   applicationId: applicationId!,
+                  techStack: templateId,
                   appName,
                   traceId: traceId!,
                   agentState: completeParsedMessage.message.agentState,
@@ -984,6 +991,7 @@ function storeDevLogs(
 async function appCreation({
   applicationId,
   appName,
+  techStack,
   traceId,
   agentState,
   githubEntity,
@@ -995,6 +1003,7 @@ async function appCreation({
 }: {
   applicationId: string;
   appName: string;
+  techStack: TemplateId;
   traceId: TraceId;
   agentState: AgentSseEvent['message']['agentState'];
   githubEntity: GithubEntityInitialized;
@@ -1033,6 +1042,7 @@ async function appCreation({
     databricksApiKey: requestBody.databricksApiKey,
     databricksHost: requestBody.databricksHost,
     files,
+    techStack,
   });
 
   streamLog(

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -44,6 +44,7 @@ export const apps = pgTable(
     appUrl: text(),
     databricksApiKey: text(),
     databricksHost: text(),
+    techStack: text('techStack').notNull().default('trpc_agent'), // 'trpc_agent' | 'nicegui_agent' | 'laravel_agent';
   },
   (table) => [index('idx_apps_ownerid_id').on(table.ownerId, table.id)],
 );


### PR DESCRIPTION
## Description

This PR adds tech stack support to the backend by introducing a `techStack` field to the apps table and updating the conversation management system to handle different technology stacks.

**FEATURES**
- Add `techStack` column to apps table with default value 'trpc_agent'
- Update conversation manager to track tech stack per conversation
- Pass tech stack through message handling pipeline
- Include tech stack in app listing API response
- Support tech stack selection during app creation

**FIXES**
- N/A

**BREAKING CHANGES**
- N/A (backward compatible with default values)

## Test Plan

- [ ] Verify database migration applies successfully
- [ ] Test app creation with different tech stack values
- [ ] Confirm conversation management preserves tech stack context
- [ ] Validate API responses include tech stack information
- [ ] Test backward compatibility with existing apps

🔍 Generated with [Claude Code](https://claude.ai/code)