### PR TITLE
fix: platform error messages

### DIFF
--- a/packages/core/agent-message.ts
+++ b/packages/core/agent-message.ts
@@ -170,15 +170,17 @@ export class PlatformMessage {
 export class StreamingError {
   error: string;
   traceId?: TraceId;
+  appId?: ApplicationId;
   message: AgentSseEventMessage;
 
-  constructor(error: string, traceId?: TraceId) {
+  constructor(error: string, appId: ApplicationId, traceId?: TraceId) {
     this.error = error;
     this.traceId = traceId;
     this.message = {
       kind: MessageKind.RUNTIME_ERROR,
       messages: [{ role: PromptKind.ASSISTANT, content: error }],
     };
+    this.appId = appId;
   }
 }
 
@@ -189,4 +191,11 @@ export interface Message {
   kind: MessageKind;
   metadata?: Record<string, any>;
   isHistory?: boolean;
+}
+
+export function extractApplicationIdFromTraceId(traceId: TraceId) {
+  const appPart = traceId.split('.')[0];
+  const applicationId = appPart?.replace('app-', '').replace('temp-', '');
+
+  return applicationId;
 }


### PR DESCRIPTION
## Description

This PR aims to fix an issue in Web, where it didn't show Platform thrown error messages.

The issue was that we don't show messages that don't have a specific `appID` attached, which was the case for Platform Error messages.

I simply added it and it started working.

## Test Plan

<img width="916" height="649" alt="image" src="https://github.com/user-attachments/assets/121f08e8-c8e5-47d3-b7d0-cc62ad5cf12e" />


