### PR TITLE
feat: add daily limit of 50 apps, including staff apps

### DIFF
--- a/apps/backend/src/apps/apps-limit.ts
+++ b/apps/backend/src/apps/apps-limit.ts
@@ -1,0 +1,49 @@
+import { and, count, gt } from 'drizzle-orm';
+import { app } from '../app';
+import { apps, db } from '../db';
+import type { FastifyRequest } from 'fastify';
+
+export const DAILY_APPS_LIMIT = Number(process.env.DAILY_APP_LIMIT) || 50;
+const getCurrentDayStart = (): Date => {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  return today;
+};
+export const getAppsDailyLimitResetTime = (): Date => {
+  const nextResetDate = new Date();
+  nextResetDate.setUTCDate(nextResetDate.getUTCDate() + 1);
+  nextResetDate.setUTCHours(0, 0, 0, 0);
+
+  return nextResetDate;
+};
+
+async function platformHasReachedDailyAppsLimit(): Promise<boolean> {
+  const startOfDay = getCurrentDayStart();
+
+  const appsCountResult = await db
+    .select({ count: count() })
+    .from(apps)
+    .where(and(gt(apps.createdAt, startOfDay)));
+
+  const createdAppsTodayCount = appsCountResult[0]?.count || 0;
+  return createdAppsTodayCount >= DAILY_APPS_LIMIT;
+}
+
+export async function userReachedPlatformLimit(
+  request: FastifyRequest,
+): Promise<boolean> {
+  const user = request.user;
+  if (user.clientReadOnlyMetadata?.role === 'staff') {
+    return false;
+  }
+
+  try {
+    const isPlatformLimitReached = await platformHasReachedDailyAppsLimit();
+    return isPlatformLimitReached;
+  } catch (error) {
+    app.log.error(
+      `Error checking platform daily apps limit: ${JSON.stringify(error)}`,
+    );
+    return false;
+  }
+}

--- a/apps/web/src/external/api/adapter.ts
+++ b/apps/web/src/external/api/adapter.ts
@@ -1,3 +1,4 @@
+import { RateLimitError } from '@appdotbuild/core';
 import { getToken } from './utils';
 
 const API_BASE_URL =
@@ -36,18 +37,14 @@ async function request<T>(
   });
 
   if (!response.ok) {
-    const error = await response.text();
+    const errorBody = await response.json();
 
     // Handle rate limit error specifically
     if (response.status === 429) {
-      const rateLimitError = new Error(
-        'Daily message limit exceeded. Please try again tomorrow.',
-      );
-      (rateLimitError as any).status = 429;
-      throw rateLimitError;
+      throw new RateLimitError(errorBody.message);
     }
 
-    throw new Error(`API Error: ${response.status} - ${error}`);
+    throw new Error(`API Error: ${response.status} - ${errorBody.message}`);
   }
 
   // return Response directly for SSE, parse JSON for other types

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -16,3 +16,4 @@ export * from './types/api';
 export * from './types/utils';
 export * from './types/analytics';
 export * from './types/agent-snapshots';
+export * from './platform-api/error';

--- a/packages/core/platform-api/error.ts
+++ b/packages/core/platform-api/error.ts
@@ -1,0 +1,20 @@
+export const API_ERROR_CODE = {
+  DAILY_APPS_LIMIT_REACHED: 'daily_apps_limit_reached',
+  DAILY_MESSAGE_LIMIT_REACHED: 'daily_message_limit_reached',
+} as const;
+
+export class RateLimitError extends Error {
+  status: number;
+  retryAfter?: number;
+
+  constructor(message: string, retryAfter?: number) {
+    super(message);
+    this.name = 'RateLimitError';
+    this.status = 429;
+    this.retryAfter = retryAfter;
+  }
+}
+
+export function isRateLimitError(error: Error): error is RateLimitError {
+  return error instanceof RateLimitError;
+}

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -12,6 +12,11 @@ export type UserMessageLimit = {
   nextResetTime: Date;
 };
 
+export type PlatformAppsLimitHeaders = {
+  'x-daily-apps-limit': number;
+  'x-daily-apps-reset': string; // ISO string of Date
+};
+
 export type MessageLimitHeaders = {
   'x-dailylimit-limit': number;
   'x-dailylimit-remaining': number;
@@ -19,26 +24,16 @@ export type MessageLimitHeaders = {
   'x-dailylimit-reset': string; // ISO string of Date
 };
 
-export type Pagination = {
+type Pagination = {
   total: number;
   page: number;
   limit: number;
   totalPages: number;
 };
-export type Chatbot = {
-  id: string;
-  name: string;
-  flyAppId?: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-  ownerId: string;
-};
+
 export type Paginated<T> = {
   data: T[];
   pagination: Pagination;
-};
-export type ReadUrl = {
-  readUrl: string;
 };
 
 export type AppPrompts = {


### PR DESCRIPTION
## Description

This PR aims to introduce an 50 apps per day limit that is platform wide.

Staff people can still continue creating apps, but their apps still count towards the total number of apps.