### PR TITLE
feat: add delete endpoint for apps with cascading cleanup

### DIFF
--- a/apps/backend/drizzle/0028_clever_nitro.sql
+++ b/apps/backend/drizzle/0028_clever_nitro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "apps" ADD COLUMN "deletedAt" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "deployments" ADD COLUMN "deletedAt" timestamp with time zone;

--- a/apps/backend/drizzle/meta/0028_snapshot.json
+++ b/apps/backend/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,440 @@
+{
+  "id": "06adc431-9f5e-4adf-8752-4d3d8115c112",
+  "prevId": "6e81cd70-5008-44eb-89ba-22c01e82e50c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_prompts": {
+      "name": "app_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_app_prompts_appid_createdat": {
+          "name": "idx_app_prompts_appid_createdat",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_prompts_appId_apps_id_fk": {
+          "name": "app_prompts_appId_apps_id_fk",
+          "tableFrom": "app_prompts",
+          "tableTo": "apps",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppId": {
+          "name": "flyAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3Checksum": {
+          "name": "s3Checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployStatus": {
+          "name": "deployStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "traceId": {
+          "name": "traceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentState": {
+          "name": "agentState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedSuccess": {
+          "name": "receivedSuccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recompileInProgress": {
+          "name": "recompileInProgress",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clientSource": {
+          "name": "clientSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slack'"
+        },
+        "repositoryUrl": {
+          "name": "repositoryUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebAppId": {
+          "name": "koyebAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebServiceId": {
+          "name": "koyebServiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebDomainId": {
+          "name": "koyebDomainId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonProjectId": {
+          "name": "neonProjectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appUrl": {
+          "name": "appUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databricksApiKey": {
+          "name": "databricksApiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databricksHost": {
+          "name": "databricksHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "techStack": {
+          "name": "techStack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trpc_agent'"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_apps_ownerid_id": {
+          "name": "idx_apps_ownerid_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_message_limits": {
+      "name": "custom_message_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dailyLimit": {
+          "name": "dailyLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_message_limits_userId_unique": {
+          "name": "custom_message_limits_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "appId": {
+          "name": "appId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgId": {
+          "name": "koyebOrgId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgEcrSecretId": {
+          "name": "koyebOrgEcrSecretId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koyebOrgName": {
+          "name": "koyebOrgName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ownerid": {
+          "name": "idx_ownerid",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_appId_apps_id_fk": {
+          "name": "deployments_appId_apps_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "apps",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1753449825017,
       "tag": "0027_broad_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1755612975450,
+      "tag": "0028_clever_nitro",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/apps/app-by-id.ts
+++ b/apps/backend/src/apps/app-by-id.ts
@@ -1,5 +1,5 @@
 import type { App } from '@appdotbuild/core/types/api';
-import { and, eq, getTableColumns } from 'drizzle-orm';
+import { and, eq, getTableColumns, isNull } from 'drizzle-orm';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { apps, db } from '../db';
 import { validate } from 'uuid';
@@ -22,7 +22,9 @@ export async function appById(
       s3Checksum: apps.s3Checksum,
     })
     .from(apps)
-    .where(and(eq(apps.id, id), eq(apps.ownerId, user.id)));
+    .where(
+      and(eq(apps.id, id), eq(apps.ownerId, user.id), isNull(apps.deletedAt)),
+    );
 
   if (!app || !app.length) {
     return reply.status(404).send({

--- a/apps/backend/src/apps/app-history.ts
+++ b/apps/backend/src/apps/app-history.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull } from 'drizzle-orm';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { appPrompts, apps, db, type AppPrompts } from '../db';
 import { validate } from 'uuid';
@@ -42,7 +42,9 @@ export async function getAppPromptHistory(
   const application = await db
     .select()
     .from(apps)
-    .where(and(eq(apps.id, appId), eq(apps.ownerId, userId)));
+    .where(
+      and(eq(apps.id, appId), eq(apps.ownerId, userId), isNull(apps.deletedAt)),
+    );
 
   if (!application || application.length === 0) {
     return null;

--- a/apps/backend/src/apps/delete-app.ts
+++ b/apps/backend/src/apps/delete-app.ts
@@ -1,0 +1,349 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { validate } from 'uuid';
+import { apps, appPrompts, deployments, db } from '../db';
+import {
+  deleteKoyebService,
+  deleteKoyebDomain,
+  deleteKoyebApp,
+  deleteKoyebOrganization,
+  getOrganizationToken,
+} from '../deploy/koyeb';
+import { deleteNeonProject } from '../deploy/neon';
+import { deleteECRImages, deleteECRRepository } from '../ecr';
+import { logger } from '../logger';
+
+export async function deleteApp(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  const user = request.user;
+  const { id } = request.params as { id: string };
+
+  if (!validate(id)) {
+    return reply.status(400).send({ error: 'Invalid app ID' });
+  }
+
+  try {
+    const app = await db
+      .select({
+        id: apps.id,
+        name: apps.name,
+        ownerId: apps.ownerId,
+        koyebAppId: apps.koyebAppId,
+        koyebServiceId: apps.koyebServiceId,
+        koyebDomainId: apps.koyebDomainId,
+        neonProjectId: apps.neonProjectId,
+        githubUsername: apps.githubUsername,
+        deletedAt: apps.deletedAt,
+      })
+      .from(apps)
+      .where(and(eq(apps.id, id), eq(apps.ownerId, user.id)));
+
+    if (!app || app.length === 0) {
+      return reply.status(404).send({
+        error: 'App not found',
+      });
+    }
+
+    const appData = app[0]!;
+
+    // Check if app is already deleted
+    if (appData.deletedAt) {
+      return reply.status(400).send({
+        error: 'App is already deleted',
+      });
+    }
+
+    // Get organization info and check remaining deployments (for Koyeb cleanup decisions)
+    const userDeployments = await db
+      .select({
+        koyebOrgId: deployments.koyebOrgId,
+        appId: deployments.appId,
+      })
+      .from(deployments)
+      .where(
+        and(eq(deployments.ownerId, user.id), isNull(deployments.deletedAt)),
+      );
+
+    const koyebOrgId = userDeployments[0]?.koyebOrgId;
+    const remainingDeployments = userDeployments.filter((d) => d.appId !== id);
+    const isLastActiveDeployment = remainingDeployments.length === 0;
+
+    await db.delete(appPrompts).where(eq(appPrompts.appId, id));
+    logger.info('Hard deleted app prompts', { appId: id });
+
+    await db
+      .update(deployments)
+      .set({ deletedAt: new Date() })
+      .where(eq(deployments.appId, id));
+    logger.info('Soft deleted deployment records', { appId: id });
+
+    // Phase 2: Soft delete the main app record (preserve for analytics)
+    await db
+      .update(apps)
+      .set({
+        deletedAt: new Date(),
+        updatedAt: new Date(),
+        koyebAppId: null,
+        koyebServiceId: null,
+        koyebDomainId: null,
+        neonProjectId: null,
+      })
+      .where(eq(apps.id, id));
+    logger.info('Soft deleted main app record', { appId: id });
+
+    await cleanupKoyebResources({
+      appId: id,
+      ownerId: user.id,
+      koyebServiceId: appData.koyebServiceId,
+      koyebDomainId: appData.koyebDomainId,
+      koyebAppId: appData.koyebAppId,
+      koyebOrgId: koyebOrgId,
+      isLastActiveDeployment: isLastActiveDeployment,
+    });
+
+    await cleanupNeonResources({
+      appId: id,
+      neonProjectId: appData.neonProjectId,
+    });
+
+    await cleanupECRResources({
+      appId: id,
+      githubUsername: appData.githubUsername,
+    });
+
+    return reply.status(200).send({
+      message: 'App deleted successfully',
+      appId: id,
+    });
+  } catch (error) {
+    logger.error('Error deleting app', {
+      appId: id,
+      userId: user.id,
+      error: error instanceof Error ? error.message : error,
+    });
+
+    return reply.status(500).send({
+      error: 'Internal server error while deleting app',
+    });
+  }
+}
+
+async function cleanupKoyebResources({
+  appId,
+  ownerId,
+  koyebServiceId,
+  koyebDomainId,
+  koyebAppId,
+  koyebOrgId,
+  isLastActiveDeployment,
+}: {
+  appId: string;
+  ownerId: string;
+  koyebServiceId: string | null;
+  koyebDomainId: string | null;
+  koyebAppId: string | null;
+  koyebOrgId: string | null | undefined;
+  isLastActiveDeployment: boolean;
+}) {
+  // Skip if no Koyeb resources to clean up
+  if (!koyebServiceId && !koyebDomainId && !koyebAppId) {
+    logger.info('No Koyeb resources to clean up', { appId });
+    return;
+  }
+
+  try {
+    if (!koyebOrgId) {
+      logger.warn('No Koyeb organization found for user, skipping cleanup', {
+        appId,
+        ownerId,
+      });
+      return;
+    }
+
+    const userToken = await getOrganizationToken(koyebOrgId);
+
+    logger.info('Starting Koyeb resource cleanup', {
+      appId,
+      hasService: !!koyebServiceId,
+      hasDomain: !!koyebDomainId,
+      hasApp: !!koyebAppId,
+    });
+
+    if (koyebServiceId) {
+      try {
+        await deleteKoyebService({
+          serviceId: koyebServiceId,
+          token: userToken,
+        });
+        logger.info('Deleted Koyeb service', {
+          appId,
+          serviceId: koyebServiceId,
+        });
+      } catch (error) {
+        logger.error('Failed to delete Koyeb service (continuing)', {
+          appId,
+          serviceId: koyebServiceId,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
+    }
+
+    if (koyebDomainId) {
+      try {
+        await deleteKoyebDomain({
+          domainId: koyebDomainId,
+          token: userToken,
+        });
+        logger.info('Deleted Koyeb domain', {
+          appId,
+          domainId: koyebDomainId,
+        });
+      } catch (error) {
+        logger.error('Failed to delete Koyeb domain (continuing)', {
+          appId,
+          domainId: koyebDomainId,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
+    }
+
+    if (koyebAppId) {
+      try {
+        await deleteKoyebApp({
+          appId: koyebAppId,
+          token: userToken,
+        });
+        logger.info('Deleted Koyeb app', {
+          appId,
+          koyebAppId: koyebAppId,
+        });
+      } catch (error) {
+        logger.error('Failed to delete Koyeb app (continuing)', {
+          appId,
+          koyebAppId: koyebAppId,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
+    }
+
+    if (isLastActiveDeployment && koyebOrgId) {
+      try {
+        logger.info('Deleting Koyeb organization (last active deployment)', {
+          appId,
+          koyebOrgId,
+          ownerId,
+        });
+
+        await deleteKoyebOrganization({
+          orgId: koyebOrgId,
+          token: userToken,
+        });
+
+        logger.info('Successfully deleted Koyeb organization', {
+          appId,
+          koyebOrgId,
+        });
+      } catch (error) {
+        logger.error('Failed to delete Koyeb organization (continuing)', {
+          appId,
+          koyebOrgId,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
+    } else {
+      logger.info('Keeping Koyeb organization (user has other deployments)', {
+        appId,
+        koyebOrgId,
+        isLastActiveDeployment,
+      });
+    }
+
+    logger.info('Koyeb resource cleanup completed', { appId });
+  } catch (error) {
+    logger.error('Failed to clean up Koyeb resources', {
+      appId,
+      ownerId,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+}
+
+async function cleanupNeonResources({
+  appId,
+  neonProjectId,
+}: {
+  appId: string;
+  neonProjectId: string | null;
+}) {
+  if (!neonProjectId) {
+    logger.info('No Neon project to clean up', { appId });
+    return;
+  }
+
+  try {
+    logger.info('Starting Neon project cleanup', {
+      appId,
+      neonProjectId,
+    });
+
+    await deleteNeonProject({
+      projectId: neonProjectId,
+    });
+
+    logger.info('Neon project cleanup completed', {
+      appId,
+      neonProjectId,
+    });
+  } catch (error) {
+    logger.error('Failed to clean up Neon project', {
+      appId,
+      neonProjectId,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+}
+
+async function cleanupECRResources({
+  appId,
+  githubUsername,
+}: {
+  appId: string;
+  githubUsername: string | null;
+}) {
+  if (!githubUsername) {
+    logger.info('No GitHub username available, skipping ECR cleanup', {
+      appId,
+    });
+    return;
+  }
+
+  try {
+    logger.info('Starting ECR resources cleanup', {
+      appId,
+      githubUsername,
+    });
+
+    await deleteECRImages({
+      appId,
+      githubUsername,
+    });
+
+    await deleteECRRepository({
+      appId,
+      githubUsername,
+    });
+
+    logger.info('ECR resources cleanup completed', {
+      appId,
+      githubUsername,
+    });
+  } catch (error) {
+    logger.error('Failed to clean up ECR resources', {
+      appId,
+      githubUsername,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+}

--- a/apps/backend/src/apps/index.ts
+++ b/apps/backend/src/apps/index.ts
@@ -1,6 +1,7 @@
 export * from './admin/apps';
 export * from './app-by-id';
 export * from './create-app';
+export * from './delete-app';
 export * from './list';
 export * from './message';
 export * from './message-limit';

--- a/apps/backend/src/apps/list.ts
+++ b/apps/backend/src/apps/list.ts
@@ -1,5 +1,5 @@
 import type { Paginated } from '@appdotbuild/core';
-import { desc, eq, getTableColumns, sql } from 'drizzle-orm';
+import { desc, eq, getTableColumns, sql, and, isNull } from 'drizzle-orm';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { apps, db } from '../db';
 import type { App } from '../db/schema';
@@ -43,12 +43,12 @@ export async function listApps(
   const countResultP = db
     .select({ count: sql`count(*)` })
     .from(apps)
-    .where(eq(apps.ownerId, user.id));
+    .where(and(eq(apps.ownerId, user.id), isNull(apps.deletedAt)));
 
   const appsP = db
     .select({ id, appName, name, createdAt, techStack })
     .from(apps)
-    .where(eq(apps.ownerId, user.id))
+    .where(and(eq(apps.ownerId, user.id), isNull(apps.deletedAt)))
     .orderBy(desc(apps.createdAt))
     .limit(pagesize)
     .offset(offset);

--- a/apps/backend/src/apps/message.ts
+++ b/apps/backend/src/apps/message.ts
@@ -26,7 +26,7 @@ import {
 } from '@appdotbuild/core';
 import { nodeEventSource } from '@llm-eaf/node-event-source';
 import { createSession, type Session } from 'better-sse';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql, isNull } from 'drizzle-orm';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { v4 as uuidv4, validate } from 'uuid';
 import { app } from '../app';
@@ -290,7 +290,13 @@ export async function postMessage(
         const application = await db
           .select()
           .from(apps)
-          .where(and(eq(apps.id, applicationId), eq(apps.ownerId, userId)));
+          .where(
+            and(
+              eq(apps.id, applicationId),
+              eq(apps.ownerId, userId),
+              isNull(apps.deletedAt),
+            ),
+          );
 
         if (application.length === 0) {
           streamLog(

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -27,7 +27,6 @@ export const apps = pgTable(
     s3Checksum: text(),
     deployStatus: text().default(DeployStatus.PENDING), // pending, deploying, deployed, failed
     traceId: text(),
-    // TODO: this should be set per deployment, and not per app, so we can rollback to a previous state
     agentState: jsonb('agentState'),
     receivedSuccess: boolean('receivedSuccess').notNull().default(false),
     recompileInProgress: boolean('recompileInProgress')
@@ -45,6 +44,7 @@ export const apps = pgTable(
     databricksApiKey: text(),
     databricksHost: text(),
     techStack: text('techStack').notNull().default('trpc_agent'), // 'trpc_agent' | 'nicegui_agent' | 'laravel_agent';
+    deletedAt: timestamp('deletedAt', { withTimezone: true }),
   },
   (table) => [index('idx_apps_ownerid_id').on(table.ownerId, table.id)],
 );
@@ -83,6 +83,7 @@ export const deployments = pgTable(
     createdAt: timestamp('createdAt', { withTimezone: true })
       .notNull()
       .defaultNow(),
+    deletedAt: timestamp('deletedAt', { withTimezone: true }),
   },
   (table) => [index('idx_ownerid').on(table.ownerId)],
 );

--- a/apps/backend/src/deploy/neon.ts
+++ b/apps/backend/src/deploy/neon.ts
@@ -83,3 +83,27 @@ async function getNeonProjectConnectionString({
 
   return connectionString.data.uri;
 }
+
+export async function deleteNeonProject({ projectId }: { projectId: string }) {
+  try {
+    logger.info('Deleting Neon project', { projectId });
+
+    await neonClient.deleteProject(projectId);
+
+    logger.info('Successfully deleted Neon project', { projectId });
+    return { deleted: true, alreadyDeleted: false };
+  } catch (error: any) {
+    // Don't throw on 404 - project might already be deleted
+    if (error.status === 404 || error.statusCode === 404) {
+      logger.info('Neon project already deleted or not found', { projectId });
+      return { deleted: true, alreadyDeleted: true };
+    }
+
+    logger.error('Failed to delete Neon project', {
+      projectId,
+      error: error.message || error,
+      status: error.status || error.statusCode,
+    });
+    throw new Error(`Failed to delete Neon project: ${error.message || error}`);
+  }
+}

--- a/apps/backend/src/ecr/create-repository.ts
+++ b/apps/backend/src/ecr/create-repository.ts
@@ -2,6 +2,9 @@ import {
   ECRClient,
   CreateRepositoryCommand,
   GetAuthorizationTokenCommand,
+  BatchDeleteImageCommand,
+  ListImagesCommand,
+  DeleteRepositoryCommand,
 } from '@aws-sdk/client-ecr';
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 
@@ -101,4 +104,110 @@ export async function generateScopedPullToken(username: string) {
     expiresAt: token.expiresAt!,
     repo: repoName,
   };
+}
+
+export async function deleteECRImages({
+  appId,
+  githubUsername,
+}: {
+  appId: string;
+  githubUsername: string;
+}) {
+  const repositoryName = `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${appId}`;
+
+  try {
+    logger.info('Deleting ECR images', { repositoryName, appId });
+
+    // First, list all images in the repository
+    const listImagesResponse = await ecrClient.send(
+      new ListImagesCommand({
+        repositoryName,
+      }),
+    );
+
+    const imageIds = listImagesResponse.imageIds;
+
+    if (!imageIds || imageIds.length === 0) {
+      logger.info('No ECR images to delete', { repositoryName, appId });
+      return { deleted: true, imageCount: 0 };
+    }
+
+    // Delete all images
+    await ecrClient.send(
+      new BatchDeleteImageCommand({
+        repositoryName,
+        imageIds,
+      }),
+    );
+
+    logger.info('Successfully deleted ECR images', {
+      repositoryName,
+      appId,
+      imageCount: imageIds.length,
+    });
+
+    return { deleted: true, imageCount: imageIds.length };
+  } catch (error: any) {
+    // Don't throw on repository not found
+    if (error.name === 'RepositoryNotFoundException') {
+      logger.info('ECR repository not found (already deleted)', {
+        repositoryName,
+        appId,
+      });
+      return { deleted: true, imageCount: 0, alreadyDeleted: true };
+    }
+
+    logger.error('Failed to delete ECR images', {
+      repositoryName,
+      appId,
+      error: error.message || error,
+    });
+    throw new Error(`Failed to delete ECR images: ${error.message || error}`);
+  }
+}
+
+export async function deleteECRRepository({
+  appId,
+  githubUsername,
+}: {
+  appId: string;
+  githubUsername: string;
+}) {
+  const repositoryName = `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${appId}`;
+
+  try {
+    logger.info('Deleting ECR repository', { repositoryName, appId });
+
+    await ecrClient.send(
+      new DeleteRepositoryCommand({
+        repositoryName,
+        force: true, // Delete even if it contains images
+      }),
+    );
+
+    logger.info('Successfully deleted ECR repository', {
+      repositoryName,
+      appId,
+    });
+
+    return { deleted: true };
+  } catch (error: any) {
+    // Don't throw on repository not found
+    if (error.name === 'RepositoryNotFoundException') {
+      logger.info('ECR repository not found (already deleted)', {
+        repositoryName,
+        appId,
+      });
+      return { deleted: true, alreadyDeleted: true };
+    }
+
+    logger.error('Failed to delete ECR repository', {
+      repositoryName,
+      appId,
+      error: error.message || error,
+    });
+    throw new Error(
+      `Failed to delete ECR repository: ${error.message || error}`,
+    );
+  }
 }

--- a/apps/backend/src/ecr/create-repository.ts
+++ b/apps/backend/src/ecr/create-repository.ts
@@ -11,11 +11,18 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { ecrClient } from './client';
 import { logger } from '../logger';
 
+function getRepositoryName(githubUsername: string, appId: string) {
+  return `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${appId}`;
+}
+
 export async function createRepositoryIfNotExists(
   repositoryName: string,
   githubUsername: string,
 ) {
-  const nameSpacedRepositoryName = `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${repositoryName}`;
+  const nameSpacedRepositoryName = getRepositoryName(
+    githubUsername,
+    repositoryName,
+  );
 
   try {
     logger.info('Creating ECR repository');
@@ -113,7 +120,7 @@ export async function deleteECRImages({
   appId: string;
   githubUsername: string;
 }) {
-  const repositoryName = `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${appId}`;
+  const repositoryName = getRepositoryName(githubUsername, appId);
 
   try {
     logger.info('Deleting ECR images', { repositoryName, appId });
@@ -173,7 +180,7 @@ export async function deleteECRRepository({
   appId: string;
   githubUsername: string;
 }) {
-  const repositoryName = `${process.env.AWS_ECR_NAMESPACE}-${githubUsername}/${appId}`;
+  const repositoryName = getRepositoryName(githubUsername, appId);
 
   try {
     logger.info('Deleting ECR repository', { repositoryName, appId });

--- a/apps/backend/src/ecr/index.ts
+++ b/apps/backend/src/ecr/index.ts
@@ -2,5 +2,7 @@ export { getECRCredentials } from './ecr-credentials';
 export {
   createRepositoryIfNotExists,
   generateScopedPullToken,
+  deleteECRImages,
+  deleteECRRepository,
 } from './create-repository';
 export { getImageName } from './get-image-name';

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,6 +3,7 @@ import { config } from 'dotenv';
 import { app } from './app';
 import {
   appById,
+  deleteApp,
   getAppByIdForAdmin,
   getUserMessageLimit,
   listAllAppsForAdmin,
@@ -36,6 +37,7 @@ app.get('/auth/is-privileged-user', authHandler, async (request, reply) => {
 app.get('/apps', authHandler, listApps);
 app.get('/apps/:id', authHandler, appById);
 app.get('/apps/:id/history', authHandler, appHistory);
+app.delete('/apps/:id', authHandler, deleteApp);
 
 // *********** Admin routes ***********
 app.get(


### PR DESCRIPTION
## Description

This PR adds a comprehensive delete endpoint for apps that performs proper cascading cleanup of all associated resources while maintaining data integrity through soft deletion patterns.

**FEATURES**
- Add DELETE /apps/:id endpoint for app deletion
- Implement soft deletion for apps and deployments (preserve analytics data)
- Hard deletion of app prompts (no longer needed after app deletion)
- Cascading cleanup of external resources (Koyeb, Neon, ECR)
- Smart organization cleanup (only delete when last deployment)
- Database schema updates with deletedAt columns
- Proper error handling and logging throughout cleanup process

**FIXES**
- Updated all app queries to filter out deleted apps (isNull(apps.deletedAt))
- Updated deployment queries to respect soft deletion
- Fixed app listing to exclude deleted apps
- Fixed app-by-id endpoint to return 404 for deleted apps