### PR TITLE
feat: add delete app UI with confirmation modal

### DIFF
--- a/apps/web/src/components/chat/list/chat-item.tsx
+++ b/apps/web/src/components/chat/list/chat-item.tsx
@@ -21,7 +21,6 @@ export function ApplicationItem({ app }: ApplicationItemProps) {
     });
   };
 
-
   return (
     <div
       className="h-full bg-background border border-input rounded-lg p-4 hover:bg-muted/50 transition-colors duration-150 cursor-pointer"
@@ -41,9 +40,11 @@ export function ApplicationItem({ app }: ApplicationItemProps) {
               <h3 className="text-base font-medium text-foreground line-clamp-2 flex-1">
                 {app.appName || app.name}
               </h3>
-              <DeleteAppButton 
-                appId={app.id} 
-                appName={app.appName || app.name} 
+              <DeleteAppButton
+                appId={app.id}
+                appName={app.appName || app.name}
+                techStack={app.techStack}
+                createdDate={new Date(app.createdAt).toLocaleDateString()}
               />
             </div>
           </div>

--- a/apps/web/src/components/chat/list/chat-item.tsx
+++ b/apps/web/src/components/chat/list/chat-item.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { ChevronRight } from 'lucide-react';
 import { StackBadge } from '~/components/chat/stack/stack-badge';
 import { AnalyticsEvents, sendEvent } from '~/external/segment';
+import { DeleteAppButton } from './delete-app-button';
 
 interface ApplicationItemProps {
   app: App;
@@ -20,6 +21,7 @@ export function ApplicationItem({ app }: ApplicationItemProps) {
     });
   };
 
+
   return (
     <div
       className="h-full bg-background border border-input rounded-lg p-4 hover:bg-muted/50 transition-colors duration-150 cursor-pointer"
@@ -34,10 +36,16 @@ export function ApplicationItem({ app }: ApplicationItemProps) {
     >
       <div className="flex flex-col h-full justify-between">
         <div>
-          <div className="flex items-start justify-between gap-2 mb-2">
-            <h3 className="text-base font-medium text-foreground line-clamp-2 flex-1">
-              {app.appName || app.name}
-            </h3>
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex justify-between gap-2 w-full">
+              <h3 className="text-base font-medium text-foreground line-clamp-2 flex-1">
+                {app.appName || app.name}
+              </h3>
+              <DeleteAppButton 
+                appId={app.id} 
+                appName={app.appName || app.name} 
+              />
+            </div>
           </div>
           <p className="text-sm text-muted-foreground">
             Created {new Date(app.createdAt).toLocaleDateString()}

--- a/apps/web/src/components/chat/list/delete-app-button.tsx
+++ b/apps/web/src/components/chat/list/delete-app-button.tsx
@@ -1,4 +1,4 @@
-import { Trash } from 'lucide-react';
+import { AlertTriangle, Trash } from 'lucide-react';
 import { useState } from 'react';
 import {
   Button,
@@ -14,10 +14,17 @@ import { toast } from 'sonner';
 
 interface DeleteAppButtonProps {
   appId: string;
-  appName?: string;
+  appName: string;
+  techStack: string;
+  createdDate: string;
 }
 
-export function DeleteAppButton({ appId, appName }: DeleteAppButtonProps) {
+export function DeleteAppButton({
+  appId,
+  appName,
+  techStack,
+  createdDate,
+}: DeleteAppButtonProps) {
   const { mutateAsync: deleteApp, isPending } = useAppDelete();
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -30,11 +37,13 @@ export function DeleteAppButton({ appId, appName }: DeleteAppButtonProps) {
     e?.stopPropagation();
     deleteApp(appId)
       .then(() => {
-        setModalOpen(false);
         toast.success('App deleted successfully');
       })
       .catch(() => {
         toast.error('Failed to delete app');
+      })
+      .finally(() => {
+        setModalOpen(false);
       });
   };
 
@@ -67,12 +76,50 @@ export function DeleteAppButton({ appId, appName }: DeleteAppButtonProps) {
           showCloseButton={false}
         >
           <DialogHeader>
-            <DialogTitle>Delete App</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete <b>{appName || 'this app'}</b>?
-              Once deleted, the app will no longer be available and this action
-              cannot be undone.
-            </DialogDescription>
+            {/* Modal Header */}
+            <div className="px-6 pt-6 pb-4">
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-50 dark:bg-red-900/20 flex items-center justify-center">
+                  <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-gray-100 leading-6">
+                    Delete App
+                  </DialogTitle>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    This action cannot be undone
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Modal Body */}
+            <div className="px-6 pb-6">
+              <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-4 mb-6">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center flex-shrink-0">
+                    <div className="w-4 h-4 bg-blue-600 dark:bg-blue-400 rounded-sm" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {appName}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Created {createdDate} • {techStack}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <DialogDescription className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+                Are you sure you want to delete{' '}
+                <span className="font-medium text-gray-900 dark:text-gray-100">
+                  {appName}
+                </span>
+                ? This will permanently remove the app and all its data from
+                your account.
+              </DialogDescription>
+            </div>
           </DialogHeader>
           <DialogFooter>
             <Button

--- a/apps/web/src/components/chat/list/delete-app-button.tsx
+++ b/apps/web/src/components/chat/list/delete-app-button.tsx
@@ -1,0 +1,97 @@
+import { Trash } from 'lucide-react';
+import { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@appdotbuild/design';
+import { useAppDelete } from '~/hooks/useApp';
+import { toast } from 'sonner';
+
+interface DeleteAppButtonProps {
+  appId: string;
+  appName?: string;
+}
+
+export function DeleteAppButton({ appId, appName }: DeleteAppButtonProps) {
+  const { mutateAsync: deleteApp, isPending } = useAppDelete();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setModalOpen(true);
+  };
+
+  const handleConfirmDelete = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    deleteApp(appId)
+      .then(() => {
+        setModalOpen(false);
+        toast.success('App deleted successfully');
+      })
+      .catch(() => {
+        toast.error('Failed to delete app');
+      });
+  };
+
+  const handleCancel = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setModalOpen(false);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setModalOpen(open);
+  };
+
+  return (
+    <>
+      <Button
+        onClick={handleDeleteClick}
+        title="Delete app"
+        variant="ghost"
+        size="fit-icon"
+        className="hover:bg-destructive/10 hover:text-destructive rounded transition-colors"
+      >
+        <Trash />
+      </Button>
+
+      <Dialog open={modalOpen} onOpenChange={handleOpenChange}>
+        <DialogContent
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          showCloseButton={false}
+        >
+          <DialogHeader>
+            <DialogTitle>Delete App</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <b>{appName || 'this app'}</b>?
+              Once deleted, the app will no longer be available and this action
+              cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={isPending}
+            >
+              {isPending ? 'Deleting...' : 'Delete App'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/layout/layout.tsx
+++ b/apps/web/src/components/layout/layout.tsx
@@ -7,6 +7,7 @@ import { sendIdentify } from '~/external/segment';
 import { isAppPage } from '~/utils/router-checker';
 import { cn } from '~/lib/utils';
 import { useLayout } from '~/hooks/useLayout';
+import { Toaster } from 'sonner';
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const user = useUser();
@@ -32,6 +33,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       >
         {children}
       </main>
+      <Toaster richColors />
       <Footer isHidden={hideFooter} />
     </>
   );

--- a/apps/web/src/external/api/adapter.ts
+++ b/apps/web/src/external/api/adapter.ts
@@ -20,7 +20,6 @@ async function request<T>(
   const token = await getToken();
 
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
     Accept: acceptType ?? AcceptType.JSON,
   };
 
@@ -62,15 +61,20 @@ export const apiClient = {
     request<T>(endpoint, {
       method: 'POST',
       body: data ? JSON.stringify(data) : undefined,
+      headers: { 'Content-Type': 'application/json' },
     }),
 
   put: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
       method: 'PUT',
       body: data ? JSON.stringify(data) : undefined,
+      headers: { 'Content-Type': 'application/json' },
     }),
 
-  delete: <T>(endpoint: string) => request<T>(endpoint, { method: 'DELETE' }),
+  delete: <T>(endpoint: string) =>
+    request<T>(endpoint, {
+      method: 'DELETE',
+    }),
 
   postSSE: async ({
     endpoint,
@@ -87,6 +91,7 @@ export const apiClient = {
         method: 'POST',
         body: data ? JSON.stringify(data) : undefined,
         ...options,
+        headers: { 'Content-Type': 'application/json' },
       },
       AcceptType.SSE,
     );

--- a/apps/web/src/external/api/services.ts
+++ b/apps/web/src/external/api/services.ts
@@ -52,4 +52,5 @@ export const appsService = {
         messageId ? `?messageId=${messageId}` : ''
       }`,
     ),
+  deleteApp: (appId: string) => apiClient.delete(`/apps/${appId}`),
 };

--- a/apps/web/src/hooks/useApp.ts
+++ b/apps/web/src/hooks/useApp.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { appsService } from '~/external/api/services';
-import { APP_QUERY_KEY } from './queryKeys';
+import { APP_QUERY_KEY, APPS_QUERY_KEY } from './queryKeys';
 import { useCurrentApp } from './useCurrentApp';
 import type { TemplateId } from '@appdotbuild/core';
 
@@ -38,4 +38,14 @@ export function useApp(appId: string) {
     error,
     isError,
   };
+}
+
+export function useAppDelete() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: appsService.deleteApp,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: APPS_QUERY_KEY });
+    },
+  });
 }

--- a/apps/web/src/hooks/useApp.ts
+++ b/apps/web/src/hooks/useApp.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { appsService } from '~/external/api/services';
+import { appsService, type PaginatedResponse } from '~/external/api/services';
 import { APP_QUERY_KEY, APPS_QUERY_KEY } from './queryKeys';
 import { useCurrentApp } from './useCurrentApp';
-import type { TemplateId } from '@appdotbuild/core';
+import type { App, TemplateId } from '@appdotbuild/core';
 
 export function useApp(appId: string) {
   const { currentAppState, setCurrentAppState, setCurrentAppTemplateId } =
@@ -44,7 +44,24 @@ export function useAppDelete() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: appsService.deleteApp,
-    onSuccess: () => {
+    onSuccess: (_, appId) => {
+      console.log('onSuccess', appId);
+      const oldApps = queryClient.getQueryData(APPS_QUERY_KEY);
+      console.log('oldApps', oldApps);
+      queryClient.setQueryData(
+        APPS_QUERY_KEY,
+        (old: { pages: PaginatedResponse<App>[] }) => {
+          if (!old || !Array.isArray(old.pages)) return old;
+
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              data: page.data.filter((app) => app.id !== appId),
+            })),
+          };
+        },
+      );
       queryClient.invalidateQueries({ queryKey: APPS_QUERY_KEY });
     },
   });

--- a/packages/design/components/ui/button.tsx
+++ b/packages/design/components/ui/button.tsx
@@ -28,6 +28,7 @@ const buttonVariants = cva(
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',
+        'fit-icon': 'h-auto w-auto p-1',
         none: '',
       },
     },

--- a/packages/design/components/ui/dialog.tsx
+++ b/packages/design/components/ui/dialog.tsx
@@ -54,7 +54,17 @@ function DialogContent({
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay
+        onClick={(e) => {
+          e.stopPropagation(); // Prevent click from bubbling up
+        }}
+        onTouchStart={(e) => {
+          e.stopPropagation(); // Prevent touch event bubbling for mobile
+        }}
+        onTouchEnd={(e) => {
+          e.stopPropagation(); // Prevent touch event bubbling for mobile
+        }}
+      />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(


### PR DESCRIPTION
## Description

This PR implements a comprehensive delete app UI feature with a confirmation modal to improve the user experience when removing applications from the platform.

**FEATURES**
- Added DeleteAppButton component with trash icon and hover effects
- Implemented confirmation modal with app details display
- Added toast notifications for delete success/error feedback
- Enhanced Button and Dialog components with new variants and props
- Integrated with existing app delete API endpoint
- Added proper loading states during delete operation

**UI/UX IMPROVEMENTS**
- Confirmation modal shows app details (name, creation date, tech stack) before deletion
- Warning icon and destructive styling to indicate permanent action
- Prevents accidental deletion with clear confirmation flow
- Responsive design with proper dark mode support
- Event propagation handling to prevent unintended navigation

**TECHNICAL CHANGES**
- New DeleteAppButton component in apps/web/src/components/chat/list/
- Enhanced useApp hook with delete mutation functionality
- Updated ChatItem component to include delete button
- Improved Button component with fit-icon size variant
- Enhanced Dialog component with showCloseButton prop

## Test Plan

- [x] Verify delete button appears in app list
- [x] Confirm modal opens when delete button is clicked  
- [x] Test modal displays correct app information
- [x] Verify delete operation calls API and shows loading state
- [x] Test toast notifications for success and error cases
- [x] Ensure modal closes after successful deletion
- [x] Verify event propagation is properly handled
- [x] Test responsive design and dark mode support

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>