### PR TITLE
feat: add auto-suspend after 12 hours for koyeb services

### DIFF
--- a/.cursor/rules/global.mdc
+++ b/.cursor/rules/global.mdc
@@ -6,4 +6,4 @@ alwaysApply: true
 
 # Global rules
 
-- Follow these rules when generating new code/assets [project-ai-rules.md](mdc:app-build-cli/project-ai-rules.md)
+- use `claude.md` to guide your code generation

--- a/apps/backend/src/deploy/koyeb.ts
+++ b/apps/backend/src/deploy/koyeb.ts
@@ -667,6 +667,7 @@ function getKoyebServiceBody({
   databaseUrl: string;
   customEnvs?: KoyebEnv[];
 }) {
+  const SLEEP_IDLE_DELAY_SECONDS = 12 * 60 * 60;
   return {
     name: 'service',
     type: 'WEB',
@@ -687,7 +688,22 @@ function getKoyebServiceBody({
       })) ?? []),
     ],
     regions: ['was'],
-    scalings: [{ scopes: ['region:was'], min: 1, max: 1, targets: [] }],
+    scalings: [
+      {
+        scopes: ['region:was'],
+        min: 0,
+        max: 1,
+        targets: [
+          {
+            sleep_idle_delay: {
+              value: SLEEP_IDLE_DELAY_SECONDS,
+              deep_sleep_value: SLEEP_IDLE_DELAY_SECONDS,
+              light_sleep_value: SLEEP_IDLE_DELAY_SECONDS,
+            },
+          },
+        ],
+      },
+    ],
     instance_types: [{ scopes: ['region:was'], type: 'nano' }],
     health_checks: [],
     volumes: [],


### PR DESCRIPTION
## Description

This PR adds auto-suspend functionality to Koyeb services, automatically suspending inactive services after 12 hours to optimize resource usage and costs.

**FEATURES**
- Added auto-suspend configuration to Koyeb services with 12-hour idle delay
- Configured scaling targets with sleep_idle_delay for deep sleep and light sleep
- Updated service scaling from fixed min:1/max:1 to min:0/max:1 to allow suspension

**BREAKING CHANGES**
- Services will now automatically suspend after 12 hours of inactivity, which may cause brief cold start delays when resuming

## Test Plan

Will test in Staging.